### PR TITLE
Refactor Engine.Runner module

### DIFF
--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -203,71 +203,17 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   def handle_cast(
-        {:play, player_id, %ActionOk{action: :skill_1, value: value, timestamp: timestamp}},
+        {:play, player_id, %ActionOk{action: action, value: value, timestamp: timestamp}},
         %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
-    {:ok, game} = Game.skill_1(game, player_id, value)
+      )
+      when action in [:basic_attack, :skill_1, :skill_2, :skill_3, :skill_4] do
+    {:ok, game} = do_action(action, game, player_id, value)
 
     server_game_state = server_game_state |> Map.put(:game, game)
 
     gen_server_state =
-      Map.put(gen_server_state, :server_game_state, server_game_state) |> set_timestamp_for_player(timestamp, player_id)
-
-    {:noreply, gen_server_state}
-  end
-
-  def handle_cast(
-        {:play, player_id, %ActionOk{action: :skill_2, value: value, timestamp: timestamp}},
-        %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
-    {:ok, game} = Game.skill_2(game, player_id, value)
-
-    server_game_state = server_game_state |> Map.put(:game, game)
-
-    gen_server_state =
-      Map.put(gen_server_state, :server_game_state, server_game_state) |> set_timestamp_for_player(timestamp, player_id)
-
-    {:noreply, gen_server_state}
-  end
-
-  def handle_cast(
-        {:play, player_id, %ActionOk{action: :skill_3, value: value, timestamp: timestamp}},
-        %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
-    {:ok, game} = Game.skill_3(game, player_id, value)
-
-    server_game_state = server_game_state |> Map.put(:game, game)
-
-    gen_server_state =
-      Map.put(gen_server_state, :server_game_state, server_game_state) |> set_timestamp_for_player(timestamp, player_id)
-
-    {:noreply, gen_server_state}
-  end
-
-  def handle_cast(
-        {:play, player_id, %ActionOk{action: :skill_4, value: value, timestamp: timestamp}},
-        %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
-    {:ok, game} = Game.skill_4(game, player_id, value)
-
-    server_game_state = server_game_state |> Map.put(:game, game)
-
-    gen_server_state =
-      Map.put(gen_server_state, :server_game_state, server_game_state) |> set_timestamp_for_player(timestamp, player_id)
-
-    {:noreply, gen_server_state}
-  end
-
-  def handle_cast(
-        {:play, player_id, %ActionOk{action: :basic_attack, value: value, timestamp: timestamp}},
-        %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
-    {:ok, game} = Game.basic_attack(game, player_id, value)
-
-    server_game_state = server_game_state |> Map.put(:game, game)
-
-    gen_server_state =
-      Map.put(gen_server_state, :server_game_state, server_game_state) |> set_timestamp_for_player(timestamp, player_id)
+      Map.put(gen_server_state, :server_game_state, server_game_state)
+      |> set_timestamp_for_player(timestamp, player_id)
 
     {:noreply, gen_server_state}
   end
@@ -378,12 +324,15 @@ defmodule DarkWorldsServer.Engine.Runner do
 
   def handle_info(
         :character_selection_time_out,
-        %{selected_characters: selected_characters, max_players: max_players, players: players} = gen_server_state
+        %{selected_characters: selected_characters, max_players: max_players, players: players} =
+          gen_server_state
       )
       when map_size(selected_characters) < max_players do
-    players_with_character = Enum.map(selected_characters, fn selected_char -> selected_char.player_id end)
+    players_with_character =
+      Enum.map(selected_characters, fn selected_char -> selected_char.player_id end)
 
-    players_without_character = Enum.filter(players, fn player_id -> player_id not in players_with_character end)
+    players_without_character =
+      Enum.filter(players, fn player_id -> player_id not in players_with_character end)
 
     selected_characters =
       Enum.reduce(players_without_character, selected_characters, fn player_id, map ->
@@ -662,4 +611,10 @@ defmodule DarkWorldsServer.Engine.Runner do
 
     Game.new(config)
   end
+
+  defp do_action(:basic_attack, game, player_id, value), do: Game.basic_attack(game, player_id, value)
+  defp do_action(:skill_1, game, player_id, value), do: Game.skill_1(game, player_id, value)
+  defp do_action(:skill_2, game, player_id, value), do: Game.skill_2(game, player_id, value)
+  defp do_action(:skill_3, game, player_id, value), do: Game.skill_3(game, player_id, value)
+  defp do_action(:skill_4, game, player_id, value), do: Game.skill_4(game, player_id, value)
 end

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -127,20 +127,6 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   def handle_cast(
-        {:play, player, %ActionOk{action: :auto_attack, value: target, timestamp: timestamp}},
-        %{next_state: %{game: game} = next_state} = state
-      ) do
-    Logger.info("[#{inspect(DateTime.utc_now())}] Received target: #{inspect(target)}")
-    {:ok, game} = Game.auto_attack(game, player, player)
-
-    next_state = Map.put(next_state, :game, game)
-
-    state = Map.put(state, :next_state, next_state) |> set_timestamp_for_player(timestamp, player)
-
-    {:noreply, state}
-  end
-
-  def handle_cast(
         {:play, player, %ActionOk{action: :move_with_joystick, value: %{x: x, y: y}, timestamp: timestamp}},
         %{server_game_state: %{game: game} = server_game_state} = gen_server_state
       ) do

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -174,7 +174,7 @@ defmodule DarkWorldsServer.Engine.Runner do
   def handle_cast({:play, _, %ActionOk{action: :add_bot}}, gen_server_state) do
     game_state = gen_server_state.server_game_state
 
-    player_id = gen_server_state.current + 1
+    player_id = gen_server_state.current_players + 1
     new_game = Game.spawn_player(game_state.game, player_id)
 
     broadcast_to_darkworlds_server({:player_joined, player_id})
@@ -183,7 +183,7 @@ defmodule DarkWorldsServer.Engine.Runner do
      %{
        gen_server_state
        | server_game_state: %{game_state | game: new_game},
-         current_players: gen_server_state.current + 1
+         current_players: gen_server_state.current_players + 1
      }}
   end
 
@@ -191,17 +191,17 @@ defmodule DarkWorldsServer.Engine.Runner do
         {:disconnect, player_id},
         %{client_game_state: game_state} = gen_server_state
       ) do
-    current = gen_server_state.current - 1
+    current = gen_server_state.current_players - 1
     {:ok, game} = Game.disconnect(game_state.game, player_id)
 
     {:noreply, %{gen_server_state | client_game_state: %{game_state | game: game}, current_players: current}}
   end
 
   def handle_call({:join, player_id}, _, gen_server_state) do
-    if gen_server_state.current < gen_server_state.max do
+    if gen_server_state.current_players < gen_server_state.max do
       broadcast_to_darkworlds_server({:player_joined, player_id})
 
-      {:reply, {:ok, player_id}, %{gen_server_state | current_players: gen_server_state.current + 1}}
+      {:reply, {:ok, player_id}, %{gen_server_state | current_players: gen_server_state.current_players + 1}}
     else
       {:reply, {:error, :game_full}, gen_server_state}
     end

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -129,7 +129,7 @@ defmodule DarkWorldsServer.Engine.Runner do
   def handle_cast(
         {:play, player, %ActionOk{action: action, value: value, timestamp: timestamp}},
         %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
+      ) when action in [:move, :move_with_joystick] do
     {:ok, game} = do_move(action, game, player, value)
 
     server_game_state = %{server_game_state | game: game}

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -220,7 +220,7 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   def handle_call(:get_state, _from, gen_server_state) do
-    {:reply, gen_server_state.game_state, gen_server_state}
+    {:reply, gen_server_state.client_game_state, gen_server_state}
   end
 
   def handle_info(:all_characters_set?, gen_server_state) do

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -297,17 +297,15 @@ defmodule DarkWorldsServer.Engine.Runner do
 
   def handle_info(
         :check_player_amount,
-        gen_server_state = %{current_players: current}
-      )
-      when current > 0 do
-    Process.send_after(self(), :check_player_amount, @player_check)
-    {:noreply, gen_server_state}
-  end
-
-  def handle_info(:check_player_amount, gen_server_state = %{current_players: current})
-      when current == 0 do
-    Process.send_after(self(), :session_timeout, 500)
-    {:noreply, Map.put(gen_server_state, :has_finished?, true)}
+        gen_server_state = %{current_players: current_players}
+      ) do
+        if current_players > 0 do
+          Process.send_after(self(), :check_player_amount, @player_check)
+          {:noreply, gen_server_state}
+        else
+          Process.send_after(self(), :session_timeout, 500)
+          {:noreply, Map.put(gen_server_state, :has_finished?, true)}
+        end
   end
 
   def handle_info(:game_timeout, gen_server_state) do

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -250,42 +250,9 @@ defmodule DarkWorldsServer.Engine.Runner do
     all_characters_set?(gen_server_state)
   end
 
-  def handle_info(
-        :character_selection_time_out,
-        %{game_state: :playing} = gen_server_state
-      ) do
-    {:noreply, gen_server_state}
-  end
 
-  def handle_info(
-        :character_selection_time_out,
-        %{selected_characters: selected_characters, max_players: max_players, players: players} =
-          gen_server_state
-      )
-      when map_size(selected_characters) < max_players do
-    players_with_character =
-      Enum.map(selected_characters, fn selected_char -> selected_char.player_id end)
-
-    players_without_character =
-      Enum.filter(players, fn player_id -> player_id not in players_with_character end)
-
-    selected_characters =
-      Enum.reduce(players_without_character, selected_characters, fn player_id, map ->
-        character_name = Enum.random(["H4ck", "Muflus", "Uma"])
-        Map.put(map, player_id, character_name)
-      end)
-
-    Process.send_after(self(), :start_game, @game_start_timer_ms)
-
-    {:noreply, Map.put(gen_server_state, :selected_characters, selected_characters)}
-  end
-
-  def handle_info(
-        :character_selection_time_out,
-        gen_server_state
-      ) do
-    Process.send_after(self(), :start_game, @game_start_timer_ms)
-    {:noreply, gen_server_state}
+  def handle_info(:character_selection_time_out, gen_server_state) do
+    character_selection_time_out(gen_server_state)
   end
 
   def handle_info(:start_game, gen_server_state) do
@@ -556,6 +523,35 @@ defmodule DarkWorldsServer.Engine.Runner do
       true ->
         Process.send_after(self(), :all_characters_set?, @character_selection_check_ms)
     end
+    {:noreply, state}
+  end
+
+  defp character_selection_time_out(state) do
+    selected_characters = state[:selected_characters]
+    state = cond do
+      state[:game_state] == :playing ->
+        state
+      selected_characters and map_size(selected_characters) < state[:max_players] ->
+        players_with_character =
+          Enum.map(selected_characters, fn selected_char -> selected_char.player_id end)
+
+        players_without_character =
+          Enum.filter(state[:players], fn player_id -> player_id not in players_with_character end)
+
+        selected_characters =
+          Enum.reduce(players_without_character, selected_characters, fn player_id, map ->
+            character_name = Enum.random(["H4ck", "Muflus", "Uma"])
+            Map.put(map, player_id, character_name)
+          end)
+
+        Process.send_after(self(), :start_game, @game_start_timer_ms)
+
+        {:noreply, %{state | selected_characters: selected_characters}}
+      true ->
+        Process.send_after(self(), :start_game, @game_start_timer_ms)
+        state
+    end
+
     {:noreply, state}
   end
 

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -173,22 +173,6 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   def handle_cast(
-        {:play, player, %ActionOk{action: :attack, value: value, timestamp: timestamp}},
-        %{server_game_state: %{game: game} = server_game_state} = gen_server_state
-      ) do
-    game =
-      game
-      |> Game.attack_player(player, value)
-
-    server_game_state = server_game_state |> Map.put(:game, game)
-
-    gen_server_state =
-      Map.put(gen_server_state, :server_game_state, server_game_state) |> set_timestamp_for_player(timestamp, player)
-
-    {:noreply, gen_server_state}
-  end
-
-  def handle_cast(
         {:play, player_id, %ActionOk{action: action, value: value, timestamp: timestamp}},
         %{server_game_state: %{game: game} = server_game_state} = gen_server_state
       )

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -207,19 +207,18 @@ defmodule DarkWorldsServer.Engine.Runner do
         {:join, player_id},
         _,
         %{max_players: max, current_players: current} = gen_server_state
+      ) do
+    if current < max do
+      Phoenix.PubSub.broadcast(
+        DarkWorldsServer.PubSub,
+        Communication.pubsub_game_topic(self()),
+        {:player_joined, player_id}
       )
-      when current < max do
-    DarkWorldsServer.PubSub
-    |> Phoenix.PubSub.broadcast(
-      Communication.pubsub_game_topic(self()),
-      {:player_joined, player_id}
-    )
 
-    {:reply, {:ok, player_id}, %{gen_server_state | current_players: current + 1}}
-  end
-
-  def handle_call(:join, _, %{max_players: max, current_players: max} = gen_server_state) do
-    {:reply, {:error, :game_full}, gen_server_state}
+      {:reply, {:ok, player_id}, %{gen_server_state | current_players: current + 1}}
+    else
+      {:reply, {:error, :game_full}, gen_server_state}
+    end
   end
 
   def handle_call(

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -277,17 +277,14 @@ defmodule DarkWorldsServer.Engine.Runner do
     {:noreply, gen_server_state}
   end
 
-  def handle_info(
-        :check_player_amount,
-        gen_server_state = %{current_players: current_players}
-      ) do
-        if current_players > 0 do
-          Process.send_after(self(), :check_player_amount, @player_check)
-          {:noreply, gen_server_state}
-        else
-          Process.send_after(self(), :session_timeout, 500)
-          {:noreply, Map.put(gen_server_state, :has_finished?, true)}
-        end
+  def handle_info(:check_player_amount, gen_server_state) do
+    if gen_server_state.current_players > 0 do
+      Process.send_after(self(), :check_player_amount, @player_check)
+      {:noreply, gen_server_state}
+    else
+      Process.send_after(self(), :session_timeout, 500)
+      {:noreply, Map.put(gen_server_state, :has_finished?, true)}
+    end
   end
 
   def handle_info(:game_timeout, gen_server_state) do

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -108,13 +108,13 @@ defmodule DarkWorldsServer.Engine.Runner do
       ) do
     selected_characters = Map.put(selected_characters, player_id, character_name)
 
-    DarkWorldsServer.PubSub
-    |> Phoenix.PubSub.broadcast(
+    Phoenix.PubSub.broadcast(
+      DarkWorldsServer.PubSub,
       Communication.pubsub_game_topic(self()),
       {:selected_characters, selected_characters}
     )
 
-    {:noreply, Map.put(gen_server_state, :selected_characters, selected_characters)}
+    {:noreply, %{gen_server_state | selected_characters: selected_characters}}
   end
 
   ## This will handle the case where players could send player movement actions or attacks
@@ -248,7 +248,6 @@ defmodule DarkWorldsServer.Engine.Runner do
   def handle_info(:all_characters_set?, gen_server_state) do
     all_characters_set?(gen_server_state)
   end
-
 
   def handle_info(:character_selection_time_out, gen_server_state) do
     character_selection_time_out(gen_server_state)

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -198,7 +198,7 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   def handle_call({:join, player_id}, _, gen_server_state) do
-    if gen_server_state.current_players < gen_server_state.max do
+    if gen_server_state.current_players < gen_server_state.max_players do
       broadcast_to_darkworlds_server({:player_joined, player_id})
 
       {:reply, {:ok, player_id}, %{gen_server_state | current_players: gen_server_state.current_players + 1}}


### PR DESCRIPTION
Aims to make the `Runner` module clearer. The main idea is to have a single endpoint for each action.

- Merged `skill/attack` & `move` endpoints together.
- Eliminated multiple declarations of some endpoints (moved logic from guards to regular conditionals/helper functions)
  - `all_characters_set?`
  - `character_selection_time_out`
  - `check_player_amount`
  - `join`
- Merged `next_round` & `last_round` endpoints
- Abstracted broadcasts to `DarkWorldsServer.PubSub `

Possible improvement: on [`character_selection_time_out`](https://github.com/lambdaclass/dark_worlds_server/pull/375/files#diff-76737aa21f7d56595726b042cb812cb7e4d190810c1d6f8329930a6d351f0291R470) I didn't want to assume `state` always had a `selected_characters` key. If it does, this code could be slightly improved.
