### PR TITLE
Bots: add logic to attack players

### DIFF
--- a/client/Assets/Prefabs/PlayerBot.prefab
+++ b/client/Assets/Prefabs/PlayerBot.prefab
@@ -218,18 +218,13 @@ GameObject:
   - component: {fileID: 1787465996332106809}
   - component: {fileID: 1787465996332106808}
   - component: {fileID: 1787465996332106815}
-  - component: {fileID: 1787465996332106814}
-  - component: {fileID: 1787465996332106813}
-  - component: {fileID: 1787465996332106812}
   - component: {fileID: 1787465996332106803}
-  - component: {fileID: 1787465996332106802}
-  - component: {fileID: 1787465996332106801}
-  - component: {fileID: 1787465996332106800}
-  - component: {fileID: 1787465996332106807}
   - component: {fileID: 1787465996332106806}
   - component: {fileID: 665966516443245430}
   - component: {fileID: 2784822964762187919}
   - component: {fileID: 422279601644613764}
+  - component: {fileID: 7082106210044654820}
+  - component: {fileID: 5899080870910008477}
   m_Layer: 10
   m_Name: PlayerBot
   m_TagString: Player
@@ -432,130 +427,6 @@ MonoBehaviour:
   RotationOffsetSmoothSpeed: 1
   ForcedRotation: 0
   ForcedRotationDirection: {x: 0, y: 0, z: 0}
---- !u!114 &1787465996332106814
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80a52f88e226e0c459085cd4e4a38a7b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  ForcedCrouch: 0
-  CrawlAuthorized: 1
-  CrawlSpeed: 4
-  ResizeColliderWhenCrouched: 0
-  TranslateColliderOnCrouch: 0
-  CrouchedColliderHeight: 1.25
-  ObjectsToOffset: []
-  OffsetCrouch: {x: 0, y: 0, z: 0}
-  OffsetCrawl: {x: 0, y: 0, z: 0}
-  OffsetSpeed: 5
-  InATunnel: 0
---- !u!114 &1787465996332106813
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c752f2958a762a144a00333487ac892f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  JumpProportionalToPress: 1
-  MinimumPressTime: 0.4
-  JumpForce: 800
-  JumpHeight: 4
-  CanJumpOnTooSteepSlopes: 1
-  ResetJumpsOnTooSteepSlopes: 0
-  NumberOfJumps: 1
-  NumberOfJumpsLeft: 0
-  JumpStartFeedback: {fileID: 0}
-  JumpStopFeedback: {fileID: 0}
---- !u!114 &1787465996332106812
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 893d1a748dcc4a247b555ae136c3d0df, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  DashMode: 1
-  DashSpace: 0
-  DashDirection: {x: 0, y: 0, z: 1}
-  DashDistance: 10
-  DashDuration: 0.5
-  DashCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  AllowDashWhenJumping: 0
-  Cooldown:
-    Unlimited: 0
-    ConsumptionDuration: 2
-    PauseOnEmptyDuration: 1
-    RefillDuration: 1
-    CanInterruptRefill: 1
-    CooldownState: 0
-    CurrentDurationLeft: 0
-  InvincibleWhileDashing: 0
-  DashFeedback: {fileID: 0}
 --- !u!114 &1787465996332106803
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -590,118 +461,6 @@ MonoBehaviour:
   WalkParticles: []
   TouchTheGroundParticles: []
   TouchTheGroundSfx: []
---- !u!114 &1787465996332106802
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d103439fc2940e347937487a70ea01e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  RunSpeed: 16
-  AutoRun: 0
-  AutoRunThreshold: 0.6
---- !u!114 &1787465996332106801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a87ffdd7d8febb24b817b1d3d350bef7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  PreventJumpInButtonActivatedZone: 1
-  ButtonActivatedZone: {fileID: 0}
---- !u!114 &1787465996332106800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d3c5cde4f9ad2514f8f7c0dcdbb02e98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  MuteSfxTrackSounds: 1
-  MuteUITrackSounds: 0
-  MuteMusicTrackSounds: 0
-  MuteMasterTrackSounds: 0
-  OnPause:
-    m_PersistentCalls:
-      m_Calls: []
-  OnUnpause:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1787465996332106807
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787465996332106805}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff2b4740e8311e042a6a323eb50805bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AbilityStartSfx: {fileID: 0}
-  AbilityInProgressSfx: {fileID: 0}
-  AbilityStopSfx: {fileID: 0}
-  AbilityStartFeedbacks: {fileID: 0}
-  AbilityStopFeedbacks: {fileID: 0}
-  AbilityPermitted: 1
-  BlockingMovementStates: 
-  BlockingConditionStates: 
-  BlockingWeaponStates: 
-  Mode: 1
-  TimeScale: 0.5
-  OneTimeDuration: 1
-  LerpTimeScale: 1
-  LerpSpeed: 5
-  Cooldown:
-    Unlimited: 0
-    ConsumptionDuration: 2
-    PauseOnEmptyDuration: 1
-    RefillDuration: 1
-    CanInterruptRefill: 1
-    CooldownState: 0
-    CurrentDurationLeft: 0
 --- !u!114 &1787465996332106806
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1011,6 +770,39 @@ MonoBehaviour:
   BlockingMovementStates: 
   BlockingConditionStates: 
   BlockingWeaponStates: 
+--- !u!114 &7082106210044654820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1787465996332106805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f642f40564f9404a8e066e25a3e16a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  AbilityStartSfx: {fileID: 0}
+  AbilityInProgressSfx: {fileID: 0}
+  AbilityStopSfx: {fileID: 0}
+  AbilityStartFeedbacks: {fileID: 0}
+  AbilityStopFeedbacks: {fileID: 0}
+  AbilityPermitted: 1
+  BlockingMovementStates: 
+  BlockingConditionStates: 
+  BlockingWeaponStates: 
+--- !u!114 &5899080870910008477
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1787465996332106805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e94f98a94a8bc47ed956bcd851a1731d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7791096737884175959
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/UI/SpawnBotButton.prefab
+++ b/client/Assets/Prefabs/UI/SpawnBotButton.prefab
@@ -295,7 +295,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00444f8795c5b42e1b9128d33bd14fe1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerPrefab: {fileID: 1787465996332106805, guid: 7bf5e7183a6b3444b8111ea4d639b854,
+  playerPrefab: {fileID: 1787465996332106805, guid: 8ab0d99d24cda40dcb595686d5a6bc6e,
     type: 3}
 --- !u!1 &8589184728101377835
 GameObject:

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -140,6 +140,11 @@ public class PlayerMovement : MonoBehaviour
 
     private void executeSkillFeedback(GameObject actualPlayer, PlayerAction playerAction)
     {
+        if (actualPlayer.name.Contains("BOT"))
+        {
+            return;
+        }
+
         // TODO: Refactor
         switch (playerAction)
         {
@@ -279,7 +284,7 @@ public class PlayerMovement : MonoBehaviour
         {
             Vector3 movementDirection = new Vector3(xChange, 0f, yChange);
             movementDirection.Normalize();
-            
+
             // FIXME: Removed harcoded validation once is fixed on the backend.
             if (playerUpdate.CharacterName == "Muflus" && playerUpdate.Action == PlayerAction.ExecutingSkill2)
             {

--- a/client/Assets/ThirdParty/DogKnight/Animator/DogControl.controller
+++ b/client/Assets/ThirdParty/DogKnight/Animator/DogControl.controller
@@ -66,8 +66,8 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -91,8 +91,8 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.6428572
-  m_HasExitTime: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/server/lib/dark_worlds_server/engine/bot_player.ex
+++ b/server/lib/dark_worlds_server/engine/bot_player.ex
@@ -3,6 +3,7 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   require Logger
   alias DarkWorldsServer.Communication
   alias DarkWorldsServer.Engine.ActionOk
+  alias DarkWorldsServer.Engine.RelativePosition
   alias DarkWorldsServer.Engine.Runner
 
   #######
@@ -31,14 +32,15 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   def init({game_pid, tick_rate}) do
     game_id = Communication.pid_to_external_id(game_pid)
     Phoenix.PubSub.subscribe(DarkWorldsServer.PubSub, "game_play_#{game_id}")
-    {:ok, %{game_pid: game_pid, bots_enabled: true, game_tick_rate: tick_rate * 2, bots: %{}}}
+    {:ok, %{game_pid: game_pid, bots_enabled: true, game_tick_rate: tick_rate * 2, players: [], bots: %{}}}
   end
 
   @impl GenServer
   def handle_cast({:add_bot, bot_id}, state) do
     send(self(), {:decide_action, bot_id})
     send(self(), {:do_action, bot_id})
-    {:noreply, put_in(state, [:bots, bot_id], %{alive: true})}
+    objective = Enum.random([:random_movement, :attack_player])
+    {:noreply, put_in(state, [:bots, bot_id], %{alive: true, objective: objective})}
   end
 
   def handle_cast({:bots_enabled, toggle}, state) do
@@ -48,7 +50,7 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   @impl GenServer
   def handle_info({:decide_action, bot_id}, state) do
     bot_state = get_in(state, [:bots, bot_id])
-    new_bot_state = decide_action(bot_id, bot_state)
+    new_bot_state = decide_action(bot_id, state.players, bot_state)
     state = put_in(state, [:bots, bot_id], new_bot_state)
     {:noreply, state}
   end
@@ -60,8 +62,26 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
 
   def handle_info({:do_action, bot_id}, state) do
     bot_state = get_in(state, [:bots, bot_id])
-    do_action(bot_id, state.game_pid, state.game_tick_rate, bot_state)
+    do_action(bot_id, state.game_pid, state.game_tick_rate, state.players, bot_state)
     {:noreply, state}
+  end
+
+  def handle_info({:game_update, game_state}, state) do
+    players =
+      game_state.client_game_state.game.players
+      |> Enum.map(&Map.take(&1, [:id, :health, :position]))
+      |> Enum.sort_by(& &1.health, :desc)
+
+    bots = Enum.reduce(players, state.bots, fn (player, acc_bots) ->
+      case {player.health <= 0, acc_bots[player.id]} do
+        {true, bot} when not is_nil(bot) -> put_in(acc_bots, [player.id, :alive], false)
+        _ -> acc_bots
+      end
+    end)
+
+    Enum.each(bots, fn {bot_id, _} -> send(self(), {:think_and_do, bot_id}) end)
+
+    {:noreply, %{state | players: players, bots: bots}}
   end
 
   def handle_info(_msg, state) do
@@ -71,22 +91,67 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   #############################
   # Callbacks implementations #
   #############################
-  defp decide_action(_, %{alive: false} = bot_state) do
+  defp decide_action(_, _, %{alive: false} = bot_state) do
     bot_state
   end
 
-  defp decide_action(bot_id, bot_state) do
+  defp decide_action(bot_id, _, %{objective: :random_movement} = bot_state) do
     Process.send_after(self(), {:decide_action, bot_id}, 5_000)
     [movement] = Enum.take_random([{1.0, 1.0}, {-1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}, {0.0, 0.0}], 1)
     Map.put(bot_state, :action, {:move, movement})
   end
 
-  defp do_action(_, _, _, %{alive: false}) do
+  defp decide_action(bot_id, [], %{objective: :attack_player} = bot_state) do
+    Process.send_after(self(), {:decide_action, bot_id}, 5_000)
+    [movement] = Enum.take_random([{1.0, 1.0}, {-1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}, {0.0, 0.0}], 1)
+    Map.put(bot_state, :action, {:move, movement})
+  end
+
+  defp decide_action(bot_id, players, %{objective: :attack_player} = bot_state) do
+    Process.send_after(self(), {:decide_action, bot_id}, 5_000)
+    [player | _] =
+      Enum.reject(players, fn player -> player.id == bot_id end)
+      |> Enum.sort_by(& &1.health, :desc)
+
+    Map.put(bot_state, :action, {:try_attack, player.id})
+  end
+
+  defp do_action(_, _, _, _, %{alive: false}) do
     :noop
   end
 
-  defp do_action(bot_id, game_pid, action_tick_rate, %{action: {:move, {x, y}}}) do
+  defp do_action(bot_id, game_pid, action_tick_rate, _players, %{action: {:move, {x, y}}}) do
     Process.send_after(self(), {:do_action, bot_id}, action_tick_rate)
     Runner.play(game_pid, bot_id, %ActionOk{action: :move_with_joystick, value: %{x: x, y: y}, timestamp: nil})
+  end
+
+  defp do_action(bot_id, game_pid, action_tick_rate, players, %{action: {:try_attack, player_id}}) do
+    Process.send_after(self(), {:do_action, bot_id}, action_tick_rate)
+
+    ## TODO: Not ideal to do this iteration over the lists twice, but not the worst considering the size
+    player = Enum.find(players, fn player -> player.id == player_id end)
+    bot = Enum.find(players, fn player -> player.id == bot_id end)
+
+    x_distance = player.position.x - bot.position.x
+    y_distance = player.position.y - bot.position.y
+
+    {x, y} = calculate_circle_point(bot.position.x, bot.position.y, player.position.x, player.position.y)
+
+    if abs(x_distance) >= 20 and abs(y_distance) >= 20 do
+      Runner.play(game_pid, bot_id, %ActionOk{action: :move_with_joystick, value: %{x: x, y: y}, timestamp: nil})
+    else
+      Runner.play(game_pid, bot_id, %ActionOk{action: :basic_attack, value: %RelativePosition{x: x, y: y}, timestamp: nil})
+    end
+  end
+
+  ####################
+  # Internal helpers #
+  ####################
+  def calculate_circle_point(cx, cy, x, y) do
+    radius = 1
+    angle = Nx.atan2(x - cx, y - cy)
+    x  = Nx.cos(angle) |> Nx.multiply(radius) |> Nx.to_number()
+    y  = Nx.sin(angle) |> Nx.multiply(radius) |> Nx.to_number()
+    {x, -y}
   end
 end


### PR DESCRIPTION
Closes #355 

- [x] Bots have two behavior chosen at spawn time: move randomly or try to attack player
- [x] Player to attack is the one with the highest live
- [x] Trying to attack a player means it will be followed until close enough to try and hit with basic attack 
- [x] Fix bot model so it ~is actually H4ck~ and shows projectiles  