### PR TITLE
Fix character selection bug

### DIFF
--- a/client/Assets/Scripts/LobbyConnection.cs
+++ b/client/Assets/Scripts/LobbyConnection.cs
@@ -308,4 +308,9 @@ public class LobbyConnection : MonoBehaviour
             return "wss://" + server_ip + path;
         }
     }
+
+    public bool isConnectionOpen()
+    {
+        return ws.State == NativeWebSocket.WebSocketState.Open;
+    }
 }

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -280,4 +280,9 @@ public class SocketConnectionManager : MonoBehaviour
             return "wss://" + server_ip + path;
         }
     }
+
+    public bool isConnectionOpen()
+    {
+        return ws.State == NativeWebSocket.WebSocketState.Open;
+    }
 }

--- a/client/Assets/Scripts/UI/UICharacterItem.cs
+++ b/client/Assets/Scripts/UI/UICharacterItem.cs
@@ -10,6 +10,7 @@ public class UICharacterItem : MonoBehaviour, IPointerDownHandler
     public Text name;
     public Image artWork;
     public bool selected = false;
+
     void Start()
     {
         artWork.sprite = comCharacter.artWork;
@@ -17,17 +18,22 @@ public class UICharacterItem : MonoBehaviour, IPointerDownHandler
 
     public void OnPointerDown(PointerEventData eventData)
     {
-        selected = true;
-        if (selected)
+        if (SocketConnectionManager.Instance.isConnectionOpen())
         {
-            name.text = comCharacter.name;
-            artWork.sprite = comCharacter.selectedArtwork;
-            SendCharacterSelection();
-            transform.parent.GetComponent<CharacterSelectionUI>().DeselectCharacters(comCharacter.name);
-        }
-        else
-        {
-            artWork.sprite = comCharacter.artWork;
+            selected = true;
+            if (selected)
+            {
+                name.text = comCharacter.name;
+                artWork.sprite = comCharacter.selectedArtwork;
+                SendCharacterSelection();
+                transform.parent
+                    .GetComponent<CharacterSelectionUI>()
+                    .DeselectCharacters(comCharacter.name);
+            }
+            else
+            {
+                artWork.sprite = comCharacter.artWork;
+            }
         }
     }
 


### PR DESCRIPTION
closes #489

The bug happens when we select a character too quickly that the game didn't even connected to the server, thus, our character selection breaks and the entire game too.
In this PR, I introduced a new function called `isConnectionOpen` in the `SocketConnectionManager`, maybe in the future we can use that function for loading screens.