### PR TITLE
Close the game after all players left the game

### DIFF
--- a/client/Assets/Scenes/BackendPlayground.unity
+++ b/client/Assets/Scenes/BackendPlayground.unity
@@ -972,6 +972,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114465564483604536, guid: 9edcf7e494cf3e640b18cb7495fb179a,
+        type: 3}
+      propertyPath: ButtonPressedFirstTime.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: BackToLobbyAndCloseConnection
+      objectReference: {fileID: 0}
     - target: {fileID: 2432087870334344871, guid: 9edcf7e494cf3e640b18cb7495fb179a,
         type: 3}
       propertyPath: ButtonPressedFirstTime.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/client/Assets/Scripts/LobbyManager.cs
+++ b/client/Assets/Scripts/LobbyManager.cs
@@ -50,7 +50,6 @@ public class LobbyManager : LevelSelector
 
     public void Back()
     {
-        SocketConnectionManager.Instance.closeConnection();
         LobbyConnection.Instance.Init();
         SceneManager.LoadScene("Lobbies");
     }

--- a/client/Assets/Scripts/LobbyManager.cs
+++ b/client/Assets/Scripts/LobbyManager.cs
@@ -9,9 +9,12 @@ public class LobbyManager : LevelSelector
 {
     [SerializeField]
     GameObject playButton;
-    [SerializeField] GameObject mapList;
+
+    [SerializeField]
+    GameObject mapList;
 
     public static string LevelSelected;
+
     public override void GoToLevel()
     {
         base.GoToLevel();
@@ -47,8 +50,15 @@ public class LobbyManager : LevelSelector
 
     public void Back()
     {
+        SocketConnectionManager.Instance.closeConnection();
         LobbyConnection.Instance.Init();
         SceneManager.LoadScene("Lobbies");
+    }
+
+    public void BackToLobbyAndCloseConnection()
+    {
+        SocketConnectionManager.Instance.closeConnection();
+        Back();
     }
 
     public void SelectMap(string mapName)
@@ -60,7 +70,8 @@ public class LobbyManager : LevelSelector
     private void Update()
     {
         if (
-            !String.IsNullOrEmpty(LobbyConnection.Instance.GameSession) && LobbyConnection.Instance.playerId != 1
+            !String.IsNullOrEmpty(LobbyConnection.Instance.GameSession)
+            && LobbyConnection.Instance.playerId != 1
         )
         {
             LobbyConnection.Instance.StartGame();

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -280,4 +280,9 @@ public class SocketConnectionManager : MonoBehaviour
             return "wss://" + server_ip + path;
         }
     }
+
+    public void closeConnection()
+    {
+        ws.Close();
+    }
 }

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -248,7 +248,6 @@ defmodule DarkWorldsServer.Engine.Runner do
       ) do
     current = gen_server_state.current_players - 1
     {:ok, game} = Game.disconnect(game_state.game, player_id)
-
     {:noreply, %{gen_server_state | client_game_state: %{game_state | game: game}, current_players: current}}
   end
 
@@ -329,14 +328,14 @@ defmodule DarkWorldsServer.Engine.Runner do
       {:noreply, gen_server_state}
     else
       Process.send_after(self(), :session_timeout, 500)
-      {:noreply, Map.put(gen_server_state, :has_finished?, true)}
+      {:noreply, Map.put(gen_server_state, :game_status, :game_finished)}
     end
   end
 
   def handle_info(:game_timeout, gen_server_state) do
     Process.send_after(self(), :session_timeout, @session_timeout)
 
-    {:noreply, Map.put(gen_server_state, :has_finished?, true)}
+    {:noreply, Map.put(gen_server_state, :game_status, :game_finished)}
   end
 
   def handle_info(:session_timeout, gen_server_state) do


### PR DESCRIPTION
closes #491 

The main reason we were not closing the game when we should, is because we were not closing the web socket connections for each player. This PR adds that feature in the client and fix a bug in the runner where we were not setting properly the game status after the game finished