### PR TITLE
Fix damage overlay shader and more

### DIFF
--- a/client/Assets/Models/Characters/Minotauro-Material.mat
+++ b/client/Assets/Models/Characters/Minotauro-Material.mat
@@ -7,12 +7,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Muflus
+  m_Name: Minotauro-Material
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_ValidKeywords:
   - _NORMALMAP
-  - _PARALLAXMAP
-  - _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -61,7 +59,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _ParallaxMap:
-        m_Texture: {fileID: 2800000, guid: 89a201c21dbda4fd48f04cc6ffca8a24, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _SpecGlossMap:
@@ -84,7 +82,7 @@ Material:
     m_Floats:
     - _AlphaClip: 0
     - _Blend: 0
-    - _BumpScale: 1
+    - _BumpScale: 1.7
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
     - _Cull: 2
@@ -93,17 +91,18 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _EnvironmentReflections: 1
-    - _GlossMapScale: 0
-    - _Glossiness: 0.5
+    - _GlossMapScale: 1
+    - _Glossiness: 0.38000005
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Smoothness: 0.5
-    - _SmoothnessTextureChannel: 1
+    - _Smoothness: 0.38000005
+    - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _Surface: 0
@@ -114,9 +113,10 @@ Material:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _OverlayColor: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []
---- !u!114 &8456764890630095443
+--- !u!114 &2842775132603823811
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}

--- a/client/Assets/Models/Characters/Minotauro-Material.mat.meta
+++ b/client/Assets/Models/Characters/Minotauro-Material.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cdada00b26ffe41daae5c4cbde513dde
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Assets/Models/Characters/Muflus-Base.fbx.meta
+++ b/client/Assets/Models/Characters/Muflus-Base.fbx.meta
@@ -3,7 +3,12 @@ guid: 8204b292856974b849e0592b526ef9f7
 ModelImporter:
   serializedVersion: 21300
   internalIDToNameTable: []
-  externalObjects: {}
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Minotauro-Material
+    second: {fileID: 2100000, guid: cdada00b26ffe41daae5c4cbde513dde, type: 2}
   materials:
     materialImportMode: 2
     materialName: 0

--- a/client/Assets/Prefabs/Characters/Muflus.prefab
+++ b/client/Assets/Prefabs/Characters/Muflus.prefab
@@ -653,6 +653,17 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8881652260837056409, guid: c2e92d8d7ec3b4591bf0ad54ad743256,
         type: 3}
+      propertyPath: shader
+      value: 
+      objectReference: {fileID: -6465566751694194690, guid: 65b762670eb1b4985b173e753a58d807,
+        type: 3}
+    - target: {fileID: 8881652260837056409, guid: c2e92d8d7ec3b4591bf0ad54ad743256,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8881652260837056409, guid: c2e92d8d7ec3b4591bf0ad54ad743256,
+        type: 3}
       propertyPath: objectToHighlight
       value: 
       objectReference: {fileID: 6624899701852712067}
@@ -891,6 +902,11 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8204b292856974b849e0592b526ef9f7,
         type: 3}
       propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -607056918500283681, guid: 8204b292856974b849e0592b526ef9f7,
+        type: 3}
+      propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 8204b292856974b849e0592b526ef9f7,

--- a/client/Assets/Prefabs/OverlayShader.prefab
+++ b/client/Assets/Prefabs/OverlayShader.prefab
@@ -44,7 +44,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0cb2979601724a95a5b0bede032fa22, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shader: {fileID: 0}
+  shader: {fileID: -6465566751694194690, guid: 65b762670eb1b4985b173e753a58d807, type: 3}
   material: {fileID: 0}
   camera: {fileID: 0}
   cameraEvent: 18

--- a/client/Assets/Resources/OverlayDamageShader.shadergraph
+++ b/client/Assets/Resources/OverlayDamageShader.shadergraph
@@ -1,0 +1,382 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "53d082d48b784c1fbf0bf26716ef129f",
+    "m_Properties": [
+        {
+            "m_Id": "06303c5e44b4442c92a3d566b34c14cc"
+        }
+    ],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "3911379cf9634f1397c8ec50d151125d"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "e9cf4a680bc2459dac91a0053d9d9f87"
+        },
+        {
+            "m_Id": "b2a849d03e6248f5a7d5d1620453284e"
+        },
+        {
+            "m_Id": "53ca4c19082948528ae5ccdbfec9ee78"
+        },
+        {
+            "m_Id": "3bef1fc84064494496b2868a95577d67"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "e9cf4a680bc2459dac91a0053d9d9f87"
+            },
+            {
+                "m_Id": "b2a849d03e6248f5a7d5d1620453284e"
+            },
+            {
+                "m_Id": "53ca4c19082948528ae5ccdbfec9ee78"
+            }
+        ]
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 200.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "3bef1fc84064494496b2868a95577d67"
+            }
+        ]
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        },
+        "preventRotation": false
+    },
+    "m_Path": "Shader Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": ""
+    },
+    "m_ActiveTargets": [
+        {
+            "m_Id": "4e023a4bb5984ff9baed929aaf27a335"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "06303c5e44b4442c92a3d566b34c14cc",
+    "m_Guid": {
+        "m_GuidSerialized": "f4b61dc0-a031-4bdd-bf7c-2ecf7b7eb126"
+    },
+    "m_Name": "OverlayColor",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "OverlayColor",
+    "m_DefaultReferenceName": "_OverlayColor",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 0.0
+    },
+    "isMainColor": false,
+    "m_ColorMode": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "3911379cf9634f1397c8ec50d151125d",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "06303c5e44b4442c92a3d566b34c14cc"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalUnlitSubTarget",
+    "m_ObjectId": "3a95b801f3d84026ad302764c98d1506"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "3bef1fc84064494496b2868a95577d67",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BaseColor",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "cf33483fa0bb4ca2bd0c80ab0800d85e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BaseColor"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "491cc070d3164478b48bb5b9a7c71c90",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
+    "m_ObjectId": "4e023a4bb5984ff9baed929aaf27a335",
+    "m_ActiveSubTarget": {
+        "m_Id": "3a95b801f3d84026ad302764c98d1506"
+    },
+    "m_AllowMaterialOverride": false,
+    "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
+    "m_CustomEditorGUI": "",
+    "m_SupportVFX": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "5217bd08ede341be80c8258807a51cd1",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "53ca4c19082948528ae5ccdbfec9ee78",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "491cc070d3164478b48bb5b9a7c71c90"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "b2a849d03e6248f5a7d5d1620453284e",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5217bd08ede341be80c8258807a51cd1"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "bed7477c80b944b9815418e8092f1b18",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "cf33483fa0bb4ca2bd0c80ab0800d85e",
+    "m_Id": 0,
+    "m_DisplayName": "Base Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BaseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "e9cf4a680bc2459dac91a0053d9d9f87",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "bed7477c80b944b9815418e8092f1b18"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
+}
+

--- a/client/Assets/Resources/OverlayDamageShader.shadergraph
+++ b/client/Assets/Resources/OverlayDamageShader.shadergraph
@@ -61,7 +61,7 @@
     },
     "m_PreviewData": {
         "serializedMesh": {
-            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_SerializedMesh": "{\"mesh\":{\"fileID\":-7895665065457907091,\"guid\":\"8204b292856974b849e0592b526ef9f7\",\"type\":3}}",
             "m_Guid": ""
         },
         "preventRotation": false

--- a/client/Assets/Resources/OverlayDamageShader.shadergraph.meta
+++ b/client/Assets/Resources/OverlayDamageShader.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 65b762670eb1b4985b173e753a58d807
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/client/Assets/Scripts/OverlayEffect.cs
+++ b/client/Assets/Scripts/OverlayEffect.cs
@@ -16,34 +16,48 @@ public class OverlayEffect : MonoBehaviour
     public int selectedGroupID = 1;
 
     List<SkinnedMeshRenderer> skinnedMeshFilter = new List<SkinnedMeshRenderer>();
+
     [Header("Objects")]
     public GameObject objectToHighlight;
 
     public void OnEnable()
     {
-        if (camera == null)
-            camera = Camera.main;
+        // if (camera == null)
+        //     camera = Camera.main;
 
-        shader = Shader.Find("Unlit/OverlayShader");
-        material = new Material(shader);
-        commandBuffer = new CommandBuffer();
-        camera = Camera.main;
-        camera.AddCommandBuffer(cameraEvent, commandBuffer);
+        // // shader = Shader.Find("Unlit/OverlayShader");
+        // material = new Material(shader);
+        // commandBuffer = new CommandBuffer();
+        // camera = Camera.main;
+        // camera.AddCommandBuffer(cameraEvent, commandBuffer);
+        // print();
+        objectToHighlight.GetComponentsInChildren(skinnedMeshFilter);
+        foreach (var meshFilter in skinnedMeshFilter)
+        {
+            meshFilter.GetComponent<Renderer>().material.shader = shader;
+        }
     }
 
     public void OnDisable()
     {
-        if (commandBuffer != null && camera != null)
+        // if (commandBuffer != null && camera != null)
+        // {
+        //     camera.RemoveCommandBuffer(cameraEvent, commandBuffer);
+        //     commandBuffer.Release();
+        //     commandBuffer = null;
+        // }
+        objectToHighlight.GetComponentsInChildren(skinnedMeshFilter);
+        foreach (var meshFilter in skinnedMeshFilter)
         {
-            camera.RemoveCommandBuffer(cameraEvent, commandBuffer);
-            commandBuffer.Release();
-            commandBuffer = null;
+            meshFilter.GetComponent<Renderer>().material.shader = Shader.Find(
+                "Universal Render Pipeline/Lit"
+            );
         }
     }
 
-    void LateUpdate()
-    {
-        commandBuffer.Clear();
-        commandBuffer.DrawAllMeshes(objectToHighlight, material, 0);
-    }
+    // void LateUpdate()
+    // {
+    //     commandBuffer.Clear();
+    //     commandBuffer.DrawAllMeshes(objectToHighlight, material, 0);
+    // }
 }

--- a/client/Assets/Scripts/OverlayEffect.cs
+++ b/client/Assets/Scripts/OverlayEffect.cs
@@ -7,13 +7,6 @@ using UnityEngine.Rendering;
 public class OverlayEffect : MonoBehaviour
 {
     public Shader shader;
-    public Material material;
-    public Camera camera;
-    public CommandBuffer commandBuffer;
-
-    [Header("Settings")]
-    public CameraEvent cameraEvent = CameraEvent.BeforeImageEffects;
-    public int selectedGroupID = 1;
 
     List<SkinnedMeshRenderer> skinnedMeshFilter = new List<SkinnedMeshRenderer>();
 
@@ -22,15 +15,6 @@ public class OverlayEffect : MonoBehaviour
 
     public void OnEnable()
     {
-        // if (camera == null)
-        //     camera = Camera.main;
-
-        // // shader = Shader.Find("Unlit/OverlayShader");
-        // material = new Material(shader);
-        // commandBuffer = new CommandBuffer();
-        // camera = Camera.main;
-        // camera.AddCommandBuffer(cameraEvent, commandBuffer);
-        // print();
         objectToHighlight.GetComponentsInChildren(skinnedMeshFilter);
         foreach (var meshFilter in skinnedMeshFilter)
         {
@@ -40,12 +24,6 @@ public class OverlayEffect : MonoBehaviour
 
     public void OnDisable()
     {
-        // if (commandBuffer != null && camera != null)
-        // {
-        //     camera.RemoveCommandBuffer(cameraEvent, commandBuffer);
-        //     commandBuffer.Release();
-        //     commandBuffer = null;
-        // }
         objectToHighlight.GetComponentsInChildren(skinnedMeshFilter);
         foreach (var meshFilter in skinnedMeshFilter)
         {
@@ -54,10 +32,4 @@ public class OverlayEffect : MonoBehaviour
             );
         }
     }
-
-    // void LateUpdate()
-    // {
-    //     commandBuffer.Clear();
-    //     commandBuffer.DrawAllMeshes(objectToHighlight, material, 0);
-    // }
 }

--- a/client/Assets/Scripts/PlayerFeedbacks.cs
+++ b/client/Assets/Scripts/PlayerFeedbacks.cs
@@ -7,16 +7,26 @@ public class PlayerFeedbacks : MonoBehaviour
 {
     public void PlayDeathFeedback(GameObject player, Health healthComponent)
     {
-        if (healthComponent.CurrentHealth <= 0 && player.GetComponent<Character>().CharacterModel.activeSelf == true)
+        if (
+            healthComponent.CurrentHealth <= 0
+            && player.GetComponent<Character>().CharacterModel.activeSelf == true
+        )
         {
             healthComponent.DeathMMFeedbacks.PlayFeedbacks();
         }
     }
 
-    public void DisplayDamageRecieved(GameObject player, Health healthComponent, float playerHealth, ulong id)
+    public void DisplayDamageRecieved(
+        GameObject player,
+        Health healthComponent,
+        float playerHealth,
+        ulong id
+    )
     {
-        if (healthComponent.CurrentHealth != playerHealth &&
-        SocketConnectionManager.Instance.playerId == id)
+        if (
+            healthComponent.CurrentHealth != playerHealth
+            && SocketConnectionManager.Instance.playerId == id
+        )
         {
             healthComponent.Damage(0.001f, this.gameObject, 0, 0, Vector3.up);
         }
@@ -24,6 +34,8 @@ public class PlayerFeedbacks : MonoBehaviour
 
     public void ChangePlayerTextureOnDamage(GameObject player, float auxHealth, float playerHealth)
     {
+        // player.GetComponentInChildren<OverlayEffect>().enabled = true;
+
         if (auxHealth != playerHealth)
         {
             player.GetComponentInChildren<OverlayEffect>().enabled = true;

--- a/client/Assets/Scripts/UI/PlayerItem.cs
+++ b/client/Assets/Scripts/UI/PlayerItem.cs
@@ -34,18 +34,16 @@ public class PlayerItem : MonoBehaviour
     {
         if (id == 1)
         {
-            this.playerText.text = $"Player {id.ToString()} {characterName} HOST";
+            this.playerText.text = $"Player {id.ToString()} {characterName} HOST ";
         }
         else
         {
-            if (LobbyConnection.Instance.playerId == id)
-            {
-                this.playerText.text = $"Player {id.ToString()} {characterName} YOU";
-            }
-            else
-            {
-                this.playerText.text = $"Player {id.ToString()} {characterName}";
-            }
+            this.playerText.text = $"Player {id.ToString()} {characterName} ";
+        }
+
+        if (LobbyConnection.Instance.playerId == id)
+        {
+            this.playerText.text += "YOU";
         }
     }
 }

--- a/client/Packages/manifest.json
+++ b/client/Packages/manifest.json
@@ -18,6 +18,7 @@
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.5",
     "com.unity.ugui": "1.0.0",
+    "com.unity.visualeffectgraph": "12.1.11",
     "com.unity.visualscripting": "1.8.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/client/Packages/packages-lock.json
+++ b/client/Packages/packages-lock.json
@@ -239,6 +239,15 @@
         "com.unity.modules.imgui": "1.0.0"
       }
     },
+    "com.unity.visualeffectgraph": {
+      "version": "12.1.11",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.shadergraph": "12.1.11",
+        "com.unity.render-pipelines.core": "12.1.11"
+      }
+    },
     "com.unity.visualscripting": {
       "version": "1.8.0",
       "depth": 0,

--- a/client/ProjectSettings/QualitySettings.asset
+++ b/client/ProjectSettings/QualitySettings.asset
@@ -40,7 +40,8 @@ QualitySettings:
     asyncUploadBufferSize: 4
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
-    customRenderPipeline: {fileID: 0}
+    customRenderPipeline: {fileID: 11400000, guid: 26069ada66dc74fadac3579def5cf03c,
+      type: 2}
     excludedTargetPlatforms: []
   - serializedVersion: 2
     name: Fast

--- a/client/ProjectSettings/VFXManager.asset
+++ b/client/ProjectSettings/VFXManager.asset
@@ -3,9 +3,13 @@
 --- !u!937362698 &1
 VFXManager:
   m_ObjectHideFlags: 0
-  m_IndirectShader: {fileID: 0}
-  m_CopyBufferShader: {fileID: 0}
-  m_SortShader: {fileID: 0}
+  m_IndirectShader: {fileID: 7200000, guid: 84a17cfa13e40ae4082ef42714f0a81c, type: 3}
+  m_CopyBufferShader: {fileID: 7200000, guid: 23c51f21a3503f6428b527b01f8a2f4e, type: 3}
+  m_SortShader: {fileID: 7200000, guid: ea257ca3cfb12a642a5025e612af6b2a, type: 3}
+  m_StripUpdateShader: {fileID: 7200000, guid: 8fa6c4009fe2a4d4486c62736fc30ad8, type: 3}
   m_RenderPipeSettingsPath: 
   m_FixedTimeStep: 0.016666668
   m_MaxDeltaTime: 0.05
+  m_CompiledVersion: 4
+  m_RuntimeVersion: 22
+  m_RuntimeResources: {fileID: 11400000, guid: bc10b42afe3813544bffd38ae2cd893d, type: 2}


### PR DESCRIPTION
This PR :

- fixes the bug in main where the damage overlay shader is not displayed. 
- Adds the "YOU" label missing in the player list.
- Change the Android Render Pipeline to URP ( It was missing in the quality settings )

closes #529 
closes #524 

- [x] Tested in Unity Desktop
- [x] Tested in Android