### PR TITLE
Restore the players's statuses in a new round

### DIFF
--- a/server/native/gamestate/src/game.rs
+++ b/server/native/gamestate/src/game.rs
@@ -128,10 +128,7 @@ impl GameState {
         for player in players.iter_mut() {
             let new_position =
                 generate_new_position(&mut positions, self.board.width, self.board.height);
-            player.position.x = new_position.x;
-            player.position.y = new_position.y;
-            player.health = 100;
-            player.status = Status::ALIVE;
+            player.restore_player_status(new_position);
             board.set_cell(
                 player.position.x,
                 player.position.y,

--- a/server/native/gamestate/src/player.rs
+++ b/server/native/gamestate/src/player.rs
@@ -292,6 +292,27 @@ impl Player {
             now,
         );
     }
+
+    // This ill be helpful once the deathmatch mode starts its development
+    pub fn restore_player_status(&mut self, new_position: Position){
+        self.health = 100;
+        self.position.x = new_position.x;
+        self.position.y = new_position.y;
+        self.status = Status::ALIVE;
+        self.action = PlayerAction::NOTHING;
+        self.aoe_position = Position::new(0,0);
+        self.effects = HashMap::new();
+        self.basic_skill_cooldown_left = MillisTime{high: 0, low: 0};
+        self.skill_1_cooldown_left = MillisTime{high: 0, low: 0};
+        self.skill_2_cooldown_left = MillisTime{high: 0, low: 0};
+        self.skill_3_cooldown_left = MillisTime{high: 0, low: 0};
+        self.skill_4_cooldown_left = MillisTime{high: 0, low: 0};
+        self.basic_skill_started_at = MillisTime{high: 0, low: 0};
+        self.skill_1_started_at = MillisTime{high: 0, low: 0};
+        self.skill_2_started_at = MillisTime{high: 0, low: 0};
+        self.skill_3_started_at = MillisTime{high: 0, low: 0};
+        self.skill_4_started_at = MillisTime{high: 0, low: 0};
+    }
 }
 
 impl Position {


### PR DESCRIPTION
closes #521 

Formerly, in a new round, we were just restarting some stats from the players, now we will restore all of them (at least the ones that should be restored)