### PR TITLE
Last timestamp seen and bugs

### DIFF
--- a/client/Assets/Scripts/EventsBuffer.cs
+++ b/client/Assets/Scripts/EventsBuffer.cs
@@ -7,6 +7,8 @@ public class EventsBuffer
     const int bufferLimit = 30;
     public List<GameEvent> updatesBuffer = new List<GameEvent>();
 
+    public Dictionary<ulong, long> lastTimestampsSeen = new Dictionary<ulong, long>();
+
     public long firstTimestamp = 0;
 
     public long deltaInterpolationTime { get; set; }
@@ -76,5 +78,19 @@ public class EventsBuffer
                 : 0;
 
         return count >= 1;
+    }
+
+    public void setLastTimestampSeen(ulong playerId, long serverTimestamp)
+    {
+        lastTimestampsSeen[playerId] = serverTimestamp;
+    }
+
+    public bool timestampAlreadySeen(ulong playerId, long serverTimestamp)
+    {
+        if (!lastTimestampsSeen.ContainsKey(playerId))
+        {
+            return false;
+        }
+        return lastTimestampsSeen[playerId] == serverTimestamp;
     }
 }

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -5,6 +5,7 @@ using MoreMountains.Tools;
 using MoreMountains.TopDownEngine;
 using UnityEngine;
 using UnityEngine.UI;
+using static MoreMountains.TopDownEngine.CharacterStates;
 
 public class PlayerMovement : MonoBehaviour
 {
@@ -52,6 +53,7 @@ public class PlayerMovement : MonoBehaviour
             SocketConnectionManager.Instance.gamePlayers != null
             && SocketConnectionManager.Instance.players.Count > 0
             && SocketConnectionManager.Instance.gamePlayers.Count > 0
+            && !SocketConnectionManager.Instance.gameFinished
         )
         {
             accumulatedTime += Time.deltaTime * 1000f;

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -5,7 +5,6 @@ using MoreMountains.Tools;
 using MoreMountains.TopDownEngine;
 using UnityEngine;
 using UnityEngine.UI;
-using static MoreMountains.TopDownEngine.CharacterStates;
 
 public class PlayerMovement : MonoBehaviour
 {
@@ -232,11 +231,6 @@ public class PlayerMovement : MonoBehaviour
         if (actualPlayer.name.Contains("BOT"))
         {
             return;
-        }
-
-        if (playerAction != PlayerAction.Moving && playerAction != PlayerAction.Nothing)
-        {
-            Debug.Log(playerAction);
         }
         // TODO: Refactor
         switch (playerAction)

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -200,7 +200,15 @@ public class PlayerMovement : MonoBehaviour
             if (actualPlayer.activeSelf)
             {
                 movePlayer(actualPlayer, serverPlayerUpdate, pastTime);
-                executeSkillFeedback(actualPlayer, serverPlayerUpdate.Action);
+                if (
+                    !buffer.timestampAlreadySeen(
+                        SocketConnectionManager.Instance.gamePlayers[i].Id,
+                        gameEvent.PlayerTimestamp
+                    )
+                )
+                {
+                    executeSkillFeedback(actualPlayer, serverPlayerUpdate.Action);
+                }
             }
 
             // TODO: try to optimize GetComponent calls

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -170,11 +170,6 @@ public class PlayerMovement : MonoBehaviour
                 continue;
             }
 
-            buffer.setLastTimestampSeen(
-                SocketConnectionManager.Instance.gamePlayers[i].Id,
-                gameEvent.ServerTimestamp
-            );
-
             // This call to `new` here is extremely important for client prediction. If we don't make a copy,
             // prediction will modify the player in place, which is not what we want.
             Player serverPlayerUpdate = new Player(gameEvent.Players[i]);
@@ -203,11 +198,15 @@ public class PlayerMovement : MonoBehaviour
                 if (
                     !buffer.timestampAlreadySeen(
                         SocketConnectionManager.Instance.gamePlayers[i].Id,
-                        gameEvent.PlayerTimestamp
+                        gameEvent.ServerTimestamp
                     )
                 )
                 {
                     executeSkillFeedback(actualPlayer, serverPlayerUpdate.Action);
+                    buffer.setLastTimestampSeen(
+                        SocketConnectionManager.Instance.gamePlayers[i].Id,
+                        gameEvent.ServerTimestamp
+                    );
                 }
             }
 
@@ -235,6 +234,11 @@ public class PlayerMovement : MonoBehaviour
         if (actualPlayer.name.Contains("BOT"))
         {
             return;
+        }
+
+        if (playerAction != PlayerAction.Moving && playerAction != PlayerAction.Nothing)
+        {
+            Debug.Log(playerAction);
         }
         // TODO: Refactor
         switch (playerAction)

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -159,6 +159,21 @@ public class PlayerMovement : MonoBehaviour
                 gameEvent = buffer.lastEvent();
             }
 
+            if (
+                buffer.timestampAlreadySeen(
+                    SocketConnectionManager.Instance.gamePlayers[i].Id,
+                    gameEvent.PlayerTimestamp
+                )
+            )
+            {
+                continue;
+            }
+
+            buffer.setLastTimestampSeen(
+                SocketConnectionManager.Instance.gamePlayers[i].Id,
+                gameEvent.ServerTimestamp
+            );
+
             // This call to `new` here is extremely important for client prediction. If we don't make a copy,
             // prediction will modify the player in place, which is not what we want.
             Player serverPlayerUpdate = new Player(gameEvent.Players[i]);
@@ -212,7 +227,6 @@ public class PlayerMovement : MonoBehaviour
         {
             return;
         }
-
         // TODO: Refactor
         switch (playerAction)
         {

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -53,7 +53,6 @@ public class PlayerMovement : MonoBehaviour
             SocketConnectionManager.Instance.gamePlayers != null
             && SocketConnectionManager.Instance.players.Count > 0
             && SocketConnectionManager.Instance.gamePlayers.Count > 0
-            && !SocketConnectionManager.Instance.gameFinished
         )
         {
             accumulatedTime += Time.deltaTime * 1000f;

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -160,16 +160,6 @@ public class PlayerMovement : MonoBehaviour
                 gameEvent = buffer.lastEvent();
             }
 
-            if (
-                buffer.timestampAlreadySeen(
-                    SocketConnectionManager.Instance.gamePlayers[i].Id,
-                    gameEvent.PlayerTimestamp
-                )
-            )
-            {
-                continue;
-            }
-
             // This call to `new` here is extremely important for client prediction. If we don't make a copy,
             // prediction will modify the player in place, which is not what we want.
             Player serverPlayerUpdate = new Player(gameEvent.Players[i]);

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -46,6 +46,8 @@ public class SocketConnectionManager : MonoBehaviour
     public float playableRadius;
     public Position shrinkingCenter;
 
+    public bool gameFinished;
+
     WebSocket ws;
 
     public class Session
@@ -147,6 +149,7 @@ public class SocketConnectionManager : MonoBehaviour
                 case GameEventType.GameFinished:
                     winnerPlayer.Item1 = game_event.WinnerPlayer;
                     winnerPlayer.Item2 = game_event.WinnerPlayer.KillCount;
+                    gameFinished = true;
                     // This should be uncommented when the match end is finished
                     // game_event.Players.ToList().ForEach((player) => print("PLAYER: " + player.Id + " KILLS: " + player.KillCount + " DEATHS: " + player.DeathCount));
                     break;

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -46,8 +46,6 @@ public class SocketConnectionManager : MonoBehaviour
     public float playableRadius;
     public Position shrinkingCenter;
 
-    public bool gameFinished;
-
     WebSocket ws;
 
     public class Session
@@ -149,7 +147,6 @@ public class SocketConnectionManager : MonoBehaviour
                 case GameEventType.GameFinished:
                     winnerPlayer.Item1 = game_event.WinnerPlayer;
                     winnerPlayer.Item2 = game_event.WinnerPlayer.KillCount;
-                    gameFinished = true;
                     // This should be uncommented when the match end is finished
                     // game_event.Players.ToList().ForEach((player) => print("PLAYER: " + player.Id + " KILLS: " + player.KillCount + " DEATHS: " + player.DeathCount));
                     break;

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -351,8 +351,6 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   def handle_info(:session_timeout, gen_server_state) do
-    broadcast_to_darkworlds_server({:game_finished, gen_server_state})
-
     {:stop, :normal, gen_server_state}
   end
 

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -405,9 +405,6 @@ defmodule DarkWorldsServer.Engine.Runner do
   end
 
   defp decide_next_game_update(%{game_status: :game_finished} = gen_server_state) do
-    # This has to be done in order to apply the last attack
-    broadcast_to_darkworlds_server({:game_update, gen_server_state})
-
     [winner] =
       Enum.filter(gen_server_state.server_game_state.game.players, fn player ->
         player.status == :alive


### PR DESCRIPTION
This PR fixes the following problems:

- If the client receives and event where it has to render skill feedbacks, since the frame rate goes faster than the server updates, it ends executing the feedback multiple times. Although this is not visible because the animations has blocking states. We're fixing this by adding the last server timestamp which the client saw
- There was an error where we were sending again the start game message to the client, this was caused by the `character_selection_time_out` function in `runner.ex` that was not checking that the game has finished.
- There was an error where the last tick was not being sent with effects like the Poison, Shrink zone o projectiles.
- The shrink zone was still executing in after the game has finished because we were never checking that 