### PR TITLE
Fix use of interpolation for your own character when not using client prediction

### DIFF
--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -148,8 +148,8 @@ public class PlayerMovement : MonoBehaviour
         {
             if (
                 useInterpolation
-                && SocketConnectionManager.Instance.playerId
-                    != SocketConnectionManager.Instance.gamePlayers[i].Id
+                && (SocketConnectionManager.Instance.playerId
+                    != SocketConnectionManager.Instance.gamePlayers[i].Id || !useClientPrediction)
             )
             {
                 gameEvent = buffer.getNextEventToRender(pastTime);


### PR DESCRIPTION
Currently, if you disable client prediction interpolation does not kick in for your character, even if enabled. This fixes that