### PR TITLE
Fix interpolation breaking when alt tabbing

### DIFF
--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -23,7 +23,8 @@ public class PlayerMovement : MonoBehaviour
     public bool isAttacking = false;
     public CharacterStates.MovementStates[] BlockingMovementStates;
     public CharacterStates.CharacterConditions[] BlockingConditionStates;
-    public float accumulatedTime;
+    public long accumulatedTime;
+    public long firstTimestamp;
 
     private bool playerIsPoisoned;
 
@@ -38,6 +39,7 @@ public class PlayerMovement : MonoBehaviour
         useInterpolation = true;
         showInterpolationGhost = false;
         accumulatedTime = 0;
+        firstTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
     }
 
     private void InitBlockingStates()
@@ -54,7 +56,8 @@ public class PlayerMovement : MonoBehaviour
             && SocketConnectionManager.Instance.gamePlayers.Count > 0
         )
         {
-            accumulatedTime += Time.deltaTime * 1000f;
+            var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            accumulatedTime = (currentTimestamp - firstTimestamp);
             UpdatePlayerActions();
             UpdateProyectileActions();
         }
@@ -129,14 +132,13 @@ public class PlayerMovement : MonoBehaviour
 
     void UpdatePlayerActions()
     {
-        long auxAccumulatedTime;
         long currentTime;
         long pastTime;
         EventsBuffer buffer = SocketConnectionManager.Instance.eventsBuffer;
         GameEvent gameEvent;
 
-        auxAccumulatedTime = (long)accumulatedTime; // Casting needed to avoid calcuting numbers with floating point
-        currentTime = buffer.firstTimestamp + auxAccumulatedTime;
+
+        currentTime = buffer.firstTimestamp + accumulatedTime;
         pastTime = currentTime - buffer.deltaInterpolationTime;
 
         if (buffer.firstTimestamp == 0)

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -148,8 +148,8 @@ public class PlayerMovement : MonoBehaviour
         {
             if (
                 useInterpolation
-                && SocketConnectionManager.Instance.playerId
-                    != SocketConnectionManager.Instance.gamePlayers[i].Id
+                && (SocketConnectionManager.Instance.playerId
+                    != SocketConnectionManager.Instance.gamePlayers[i].Id || !useClientPrediction)
             )
             {
                 gameEvent = buffer.getNextEventToRender(pastTime);

--- a/client/Assets/Scripts/PlayerMovement.cs
+++ b/client/Assets/Scripts/PlayerMovement.cs
@@ -39,7 +39,6 @@ public class PlayerMovement : MonoBehaviour
         useInterpolation = true;
         showInterpolationGhost = false;
         accumulatedTime = 0;
-        firstTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
     }
 
     private void InitBlockingStates()
@@ -56,6 +55,9 @@ public class PlayerMovement : MonoBehaviour
             && SocketConnectionManager.Instance.gamePlayers.Count > 0
         )
         {
+            if (firstTimestamp == 0) {
+                firstTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            }
             var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             accumulatedTime = (currentTimestamp - firstTimestamp);
             UpdatePlayerActions();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,3 +8,4 @@
 - [IOS Build](./ios_builds.md)
 - [WebGL Builds](./webgl_builds.md)
 - [Simulating high latency](./simulating_latency.md)
+- [Common Pitfalls](./common_pitfalls.md)

--- a/docs/src/common_pitfalls.md
+++ b/docs/src/common_pitfalls.md
@@ -4,7 +4,7 @@
 
 ## Keeping track of time in Unity
 
-Some parts of the client code need to keep track of how much time has passed since the game started. Most notably, entity interpolation uses this to know which game update from the buffer it should render. There are at least two ways of keeping track of this:
+Some parts of the client code need to keep track of how much time has passed since the game started. Most notably, entity interpolation uses this to know which game update from the buffer it should render. There are at least two ways to do this:
 
 - Using the `Time` module provided by unity, with functions like `Time.deltaTime`, which gives you the time passed between frames.
 - Using Unix timestamps, keeping an initial timestamp at the beginning and then getting a new one each time we want to know how much time has passed.

--- a/docs/src/common_pitfalls.md
+++ b/docs/src/common_pitfalls.md
@@ -1,0 +1,16 @@
+# Common Pitfalls
+
+## Floating point arithmetic
+
+## Keeping track of time in Unity
+
+Some parts of the client code need to keep track of how much time has passed since the game started. Most notably, entity interpolation uses this to know which game update from the buffer it should render. There are at least two ways of keeping track of this:
+
+- Using the `Time` module provided by unity, with functions like `Time.deltaTime`, which gives you the time passed between frames.
+- Using Unix timestamps, keeping an initial timestamp at the beginning and then getting a new one each time we want to know how much time has passed.
+
+It might seem like these are equivalent, but the first one has a problem that the second one doesn't. The problem with using `Time` is that it needs to have the game running for it to apply. If you ever move the game to the background, it will stop running, frames won't be executed, and the time will essentially stop passing. If you alt-tab for one second, when you go back to the game your accumulated time is one second behind.
+
+This is a huge problem. A possible solution is to change the settings on Unity so that the game always runs, even in the background. This does not work, however, because not every platform allows for running in the background (Android, for example, forbids it).
+
+Because of all this, if you have to keep track of accumulated time, go for timestamps, not `Time`.


### PR DESCRIPTION
There was a bug on interpolation where if you moved the game to the background, the interpolation delay would be set to the max when going back into the game. This was due to the use of `Time.deltaTime` to keep track of accumulated time. 

The problem is that if the game is not running, this game time does not happen and therefore the accumulated time lags behind. 

The fix was to switch to using unix timetamps to keep track of time.

TODO:

- [x] Document this

