### PR TITLE
Small fix to interpolation

### DIFF
--- a/client/Assets/Scripts/EventsBuffer.cs
+++ b/client/Assets/Scripts/EventsBuffer.cs
@@ -69,7 +69,7 @@ public class EventsBuffer
         }
 
         if (index == (updatesBuffer.Count - 1)) {
-            nextIndex = updatesBuffer.Count;
+            nextIndex = updatesBuffer.Count - 1;
         } else {
             nextIndex = index + 1;
         }

--- a/client/Assets/Scripts/EventsBuffer.cs
+++ b/client/Assets/Scripts/EventsBuffer.cs
@@ -57,9 +57,25 @@ public class EventsBuffer
     public bool playerIsMoving(ulong playerId, long pastTime)
     {
         var count = 0;
-        GameEvent previousRenderedEvent = this.getNextEventToRender(pastTime - 30);
         GameEvent currentEventToRender = this.getNextEventToRender(pastTime);
-        GameEvent followingEventToRender = this.getNextEventToRender(pastTime + 30);
+        var index = updatesBuffer.IndexOf(currentEventToRender);
+        int previousIndex;
+        int nextIndex;
+
+        if (index == 0) {
+            previousIndex = 0;
+        } else {
+            previousIndex = index - 1;
+        }
+
+        if (index == (updatesBuffer.Count - 1)) {
+            nextIndex = updatesBuffer.Count;
+        } else {
+            nextIndex = index + 1;
+        }
+        
+        GameEvent previousRenderedEvent = updatesBuffer[previousIndex];
+        GameEvent followingEventToRender = updatesBuffer[nextIndex];
 
         count +=
             (previousRenderedEvent.Players.ToList().Find(p => p.Id == playerId)).Action


### PR DESCRIPTION
When getting the previous and next events to check for movement, we were using time (specifically, a hardcoded 30 ms) to try to index into the next and previous elements of the buffer. This can be a problem because updates are not guaranteed to always be 30 ms apart, for a variety of reasons.

Instead, this PR changes things so we simply get the next and previous events with their index. Events are guaranteed to be ordered so this is enough