### PR TITLE
Fix missing prefab in lobbyManager

### DIFF
--- a/client/Assets/Scripts/LobbyManager.cs
+++ b/client/Assets/Scripts/LobbyManager.cs
@@ -96,11 +96,13 @@ public class LobbyManager : LevelSelector
             SceneManager.LoadScene(CHARACTER_SELECTION_SCENE_NAME);
         }
 
-        if (LobbyConnection.Instance.isHost && !this.playButton.activeSelf)
+        if (this.playButton)
         {
-            this.playButton.SetActive(true);
-            this.waitingText.SetActive(false);
+            if (LobbyConnection.Instance.isHost && !this.playButton.activeSelf)
+            {
+                this.playButton.SetActive(true);
+                this.waitingText.SetActive(false);
+            }
         }
-
     }
 }


### PR DESCRIPTION
This Fix the console errors where playbutton.

PD : We should refactor the use of lobbyManager removing it from the pause splash , chatacter selection.