### PR TITLE
Lobbies Refactor

### DIFF
--- a/client/Assets/Prefabs/UI/LobbyItem.prefab
+++ b/client/Assets/Prefabs/UI/LobbyItem.prefab
@@ -417,7 +417,6 @@ GameObject:
   - component: {fileID: 7158739655978231132}
   - component: {fileID: 973697423679670818}
   - component: {fileID: 128906090582597004}
-  - component: {fileID: 7803031921548610432}
   m_Layer: 5
   m_Name: LobbyItem
   m_TagString: Untagged
@@ -512,8 +511,8 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 7803031921548610432}
-        m_TargetAssemblyTypeName: LobbiesManager, Assembly-CSharp
+      - m_Target: {fileID: 7158739655978231132}
+        m_TargetAssemblyTypeName: LobbiesListItem, Assembly-CSharp
         m_MethodName: ConnectToLobby
         m_Mode: 1
         m_Arguments:
@@ -550,22 +549,6 @@ MonoBehaviour:
   DisabledAnimationParameterName: Disabled
   PressedAnimationParameterName: Pressed
   MouseMode: 1
---- !u!114 &7803031921548610432
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6431237631302165411}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 610e661a176e54d3793b92ad9640aa97, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LevelName: Lobby
-  DoNotUseLevelManager: 0
-  DestroyPersistentCharacter: 0
-  listItem: {fileID: 7158739655978231132}
 --- !u!1 &7198850815985712903
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Scripts/LobbiesManager.cs
+++ b/client/Assets/Scripts/LobbiesManager.cs
@@ -10,6 +10,13 @@ public class LobbiesManager : LevelSelector
     [SerializeField]
     LobbiesListItem listItem;
 
+    public static LobbiesManager Instance;
+
+    void Start()
+    {
+        Instance = this;
+    }
+
     public override void GoToLevel()
     {
         base.GoToLevel();
@@ -21,9 +28,9 @@ public class LobbiesManager : LevelSelector
         StartCoroutine(WaitForLobbyCreation());
     }
 
-    public void ConnectToLobby()
+    public void ConnectToLobby(string idHash)
     {
-        StartCoroutine(WaitForLobbyJoin());
+        StartCoroutine(WaitForLobbyJoin(idHash));
     }
 
     public void Back()
@@ -61,9 +68,9 @@ public class LobbiesManager : LevelSelector
         SceneManager.LoadScene("CharacterSelection");
     }
 
-    public IEnumerator WaitForLobbyJoin()
+    public IEnumerator WaitForLobbyJoin(string idHash)
     {
-        LobbyConnection.Instance.ConnectToLobby(listItem.idHash);
+        LobbyConnection.Instance.ConnectToLobby(idHash);
         yield return new WaitUntil(() => LobbyConnection.Instance.playerId != UInt64.MaxValue);
         SceneManager.LoadScene("Lobby");
     }

--- a/client/Assets/Scripts/LobbiesManager.cs
+++ b/client/Assets/Scripts/LobbiesManager.cs
@@ -7,9 +7,6 @@ using UnityEngine.SceneManagement;
 
 public class LobbiesManager : LevelSelector
 {
-    [SerializeField]
-    LobbiesListItem listItem;
-
     public static LobbiesManager Instance;
 
     void Start()

--- a/client/Assets/Scripts/UI/LobbiesListItem.cs
+++ b/client/Assets/Scripts/UI/LobbiesListItem.cs
@@ -28,4 +28,9 @@ public class LobbiesListItem : MonoBehaviour
         yield return new WaitForSeconds(2f);
         GetComponent<MMTouchButton>().EnableButton();
     }
+
+    public void ConnectToLobby()
+    {
+        LobbiesManager.Instance.ConnectToLobby(idHash);
+    }
 }


### PR DESCRIPTION
This PR removes the instances of `LobbiesManager` that we had in the `LobbyItem`.

Now we have an Instance of `LobbiesManager` so each `lobbyItem` intanciate can access to the methods. In our case we need `ConnectToLobby(string idHash)`

closes #723 
closes #663 