### PR TITLE
Hardened SSH security in GitHub Actions.

### DIFF
--- a/.github/workflows/aws-staging-deploy.yml
+++ b/.github/workflows/aws-staging-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           set -ex
           mkdir -p ~/.ssh/
-          ssh-keyscan $HOST >> ~/.ssh/known_hosts
+          ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts
           scp -i id_ed25519_staging \
               -P ${SSH_PORT} \
               ${SCRIPT_SRC} \
@@ -61,7 +61,7 @@ jobs:
         run: |
           set -ex
           mkdir -p ~/.ssh/
-          ssh-keyscan $HOST >> ~/.ssh/known_hosts
+          ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts
           ssh -i id_ed25519_staging \
               -p ${SSH_PORT} \
               ${SSH_USERNAME}@${SSH_HOST} \

--- a/.github/workflows/aws-testing-deploy.yml
+++ b/.github/workflows/aws-testing-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -ex
           mkdir -p ~/.ssh/
-          ssh-keyscan $HOST >> ~/.ssh/known_hosts
+          ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts
           scp -i id_ed25519_testing \
               -P ${SSH_PORT} \
               ${SCRIPT_SRC} \
@@ -65,7 +65,7 @@ jobs:
         run: |
           set -ex
           mkdir -p ~/.ssh/
-          ssh-keyscan $HOST >> ~/.ssh/known_hosts
+          ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts
           ssh -i id_ed25519_testing \
               -p ${SSH_PORT} \
               ${SSH_USERNAME}@${SSH_HOST} \


### PR DESCRIPTION
This PR aims to enhance the security of the GitHub Actions workflow that involves SSH connections.
Previously, we had been using the `StrictHostKeyChecking=no` option to bypass host key verification, which introduced potential security risks.

The problem with using `StrictHostKeyChecking=no` is that it disables the verification of the remote server's identity, leaving us susceptible to man-in-the-middle attacks. To address this, we've implemented a more secure approach:

We are now using the `ssh-keyscan` command to fetch the public keys of the remote.
By appending the fetched keys to the `~/.ssh/known_hosts` file, we populate it with the host's public keys.
This eliminates the need for `StrictHostKeyChecking=no` and allows the SSH client to automatically verify the server's identity by providing our private key.
