### PR TITLE
Refresh refactor

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -1363,9 +1363,9 @@ RectTransform:
   m_Father: {fileID: 9069024631279217844}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 460.9242, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 460.55072, y: -20}
   m_SizeDelta: {x: 0, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1400874601
@@ -5430,9 +5430,9 @@ RectTransform:
   m_Father: {fileID: 9069024631279217844}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 188.5545, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 188.33044, y: -20}
   m_SizeDelta: {x: 0, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &504221036863612087
@@ -9953,7 +9953,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 628.55457, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1326514085191306140
@@ -15260,9 +15260,9 @@ RectTransform:
   m_Father: {fileID: 9069024631279217844}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 796.18494, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 796.11005, y: -20}
   m_SizeDelta: {x: 0, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6125969736173794726

--- a/client/Assets/Prefabs/Camera/LobbiesCameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/LobbiesCameraUI.prefab
@@ -148,6 +148,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1905025553364110810}
         m_TargetAssemblyTypeName: SelectServerIP, Assembly-CSharp
@@ -161,16 +164,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 2691745410626970149}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -1545,6 +1557,7 @@ GameObject:
   - component: {fileID: 1425486099329424127}
   - component: {fileID: 7693481759570521431}
   - component: {fileID: 8784269819220292848}
+  - component: {fileID: 7258747061359327656}
   m_Layer: 5
   m_Name: LobbiesContainer
   m_TagString: Untagged
@@ -1612,6 +1625,22 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7258747061359327656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425486099329424124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5a906a3ed6f6416fbb0d5bd4e2bd1d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lobbiesContainer: {fileID: 2269567885505166013}
+  lobbyItemPrefab: {fileID: 6431237631302165411, guid: 13e64695dc3a44037a7a7568727079c6,
+    type: 3}
+  noLobbiesText: {fileID: 8723296149733053187}
 --- !u!1 &1546212733417079774
 GameObject:
   m_ObjectHideFlags: 0
@@ -1705,7 +1734,6 @@ GameObject:
   - component: {fileID: 2493072116769174030}
   - component: {fileID: 6800354270745153507}
   - component: {fileID: 1241550124117571381}
-  - component: {fileID: 4251287302063571713}
   m_Layer: 5
   m_Name: NewLobby
   m_TagString: Untagged
@@ -1799,6 +1827,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 580734115480870141}
         m_TargetAssemblyTypeName: LobbiesManager, Assembly-CSharp
@@ -1824,16 +1855,13 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -1850,20 +1878,6 @@ MonoBehaviour:
   DisabledAnimationParameterName: Disabled
   PressedAnimationParameterName: Pressed
   MouseMode: 1
---- !u!114 &4251287302063571713
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1603105262504358399}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c29756d7127346488dfe477be32e28e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  notSelectedButton: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
-  selectedButton: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
 --- !u!1 &1640966383155315131
 GameObject:
   m_ObjectHideFlags: 0
@@ -2606,6 +2620,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8255375205241509355}
         m_TargetAssemblyTypeName: SelectServerIP, Assembly-CSharp
@@ -2619,16 +2636,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 2478478122330645077}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -2717,7 +2743,6 @@ MonoBehaviour:
   LevelName: CharacterSelection
   DoNotUseLevelManager: 0
   DestroyPersistentCharacter: 0
-  listItem: {fileID: 0}
 --- !u!1 &2734577476813917642
 GameObject:
   m_ObjectHideFlags: 0
@@ -3538,6 +3563,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mutedSprite: {fileID: 21300000, guid: 4fdedeada12450943898e7cb3b4b305c, type: 3}
   unmutedSprite: {fileID: 21300000, guid: 21d9f3ee932343240bec2d4eb6f34968, type: 3}
+  volumeSlider: {fileID: 0}
 --- !u!1 &4407779193814417940
 GameObject:
   m_ObjectHideFlags: 0
@@ -3552,7 +3578,6 @@ GameObject:
   - component: {fileID: 5508936240411607399}
   - component: {fileID: 3315775001322782994}
   - component: {fileID: 6212898620581885981}
-  - component: {fileID: 187844699452013922}
   m_Layer: 5
   m_Name: Server
   m_TagString: Untagged
@@ -3646,6 +3671,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 6212898620581885981}
         m_TargetAssemblyTypeName: ServersListHandler, Assembly-CSharp
@@ -3659,40 +3687,13 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 187844699452013922}
-        m_TargetAssemblyTypeName: ButtonSelectionStyles, Assembly-CSharp
-        m_MethodName: NotSelected
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 187844699452013922}
-        m_TargetAssemblyTypeName: ButtonSelectionStyles, Assembly-CSharp
-        m_MethodName: Selected
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  DisabledSprite: {fileID: 0}
+      m_Calls: []
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -3723,20 +3724,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOptions: {fileID: 7059439635865057780}
   serverName: 
---- !u!114 &187844699452013922
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4407779193814417940}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c29756d7127346488dfe477be32e28e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  notSelectedButton: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
-  selectedButton: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
 --- !u!1 &4586034129711013812
 GameObject:
   m_ObjectHideFlags: 0
@@ -4118,6 +4105,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 4536769650066377954}
         m_TargetAssemblyTypeName: SelectServerIP, Assembly-CSharp
@@ -4131,16 +4121,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 4658516447990779294}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -4885,6 +4884,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 4475727635903142075}
         m_TargetAssemblyTypeName: SelectServerIP, Assembly-CSharp
@@ -4898,16 +4900,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 4855112992570389232}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -5959,7 +5970,6 @@ GameObject:
   - component: {fileID: 2220792709368367382}
   - component: {fileID: 7038199148050063523}
   - component: {fileID: 4073895302451433295}
-  - component: {fileID: 245159641278502477}
   m_Layer: 5
   m_Name: QuickGame
   m_TagString: Untagged
@@ -6053,6 +6063,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 580734115480870141}
         m_TargetAssemblyTypeName: LobbiesManager, Assembly-CSharp
@@ -6078,37 +6091,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 245159641278502477}
-        m_TargetAssemblyTypeName: ButtonSelectionStyles, Assembly-CSharp
-        m_MethodName: NotSelected
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 245159641278502477}
-        m_TargetAssemblyTypeName: ButtonSelectionStyles, Assembly-CSharp
-        m_MethodName: Selected
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  DisabledSprite: {fileID: 0}
+      m_Calls: []
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
   PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
@@ -6128,20 +6114,6 @@ MonoBehaviour:
   DisabledAnimationParameterName: Disabled
   PressedAnimationParameterName: Pressed
   MouseMode: 1
---- !u!114 &245159641278502477
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6472191256914153022}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c29756d7127346488dfe477be32e28e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  notSelectedButton: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
-  selectedButton: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
 --- !u!1 &7059439635865057780
 GameObject:
   m_ObjectHideFlags: 0
@@ -6680,6 +6652,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8150341167402258474}
         m_TargetAssemblyTypeName: SelectServerIP, Assembly-CSharp
@@ -6693,16 +6668,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 4061438127012939230}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -7040,7 +7024,6 @@ GameObject:
   - component: {fileID: 2237232150854680030}
   - component: {fileID: 9003002262393817868}
   - component: {fileID: 6279149563321762238}
-  - component: {fileID: 6181571837480280998}
   m_Layer: 5
   m_Name: Refresh
   m_TagString: Untagged
@@ -7134,19 +7117,10 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 6279149563321762238}
-        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
-        m_MethodName: DisableButton
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 580734115480870141}
         m_TargetAssemblyTypeName: LobbiesManager, Assembly-CSharp
         m_MethodName: Refresh
@@ -7159,12 +7133,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 6181571837480280998}
-        m_TargetAssemblyTypeName: ButtonSelectionStyles, Assembly-CSharp
-        m_MethodName: NotSelected
+      - m_Target: {fileID: 7258747061359327656}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: RefreshLobbiesList
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7176,20 +7147,8 @@ MonoBehaviour:
         m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 6181571837480280998}
-        m_TargetAssemblyTypeName: ButtonSelectionStyles, Assembly-CSharp
-        m_MethodName: Selected
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  DisabledSprite: {fileID: 0}
+      m_Calls: []
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
   PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
@@ -7209,20 +7168,6 @@ MonoBehaviour:
   DisabledAnimationParameterName: Disabled
   PressedAnimationParameterName: Pressed
   MouseMode: 1
---- !u!114 &6181571837480280998
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8623420363451892913}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c29756d7127346488dfe477be32e28e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  notSelectedButton: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
-  selectedButton: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
 --- !u!1 &8723296149733053187
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/Camera/LobbiesCameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/LobbiesCameraUI.prefab
@@ -1557,7 +1557,6 @@ GameObject:
   - component: {fileID: 1425486099329424127}
   - component: {fileID: 7693481759570521431}
   - component: {fileID: 8784269819220292848}
-  - component: {fileID: 7258747061359327656}
   m_Layer: 5
   m_Name: LobbiesContainer
   m_TagString: Untagged
@@ -1625,22 +1624,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &7258747061359327656
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1425486099329424124}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c5a906a3ed6f6416fbb0d5bd4e2bd1d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  lobbiesContainer: {fileID: 2269567885505166013}
-  lobbyItemPrefab: {fileID: 6431237631302165411, guid: 13e64695dc3a44037a7a7568727079c6,
-    type: 3}
-  noLobbiesText: {fileID: 8723296149733053187}
 --- !u!1 &1546212733417079774
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/Camera/LobbiesCameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/LobbiesCameraUI.prefab
@@ -2697,6 +2697,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7844609706619734572}
   - component: {fileID: 580734115480870141}
+  - component: {fileID: 6681311028336639718}
   m_Layer: 5
   m_Name: OptionsContainer
   m_TagString: Untagged
@@ -2743,6 +2744,22 @@ MonoBehaviour:
   LevelName: CharacterSelection
   DoNotUseLevelManager: 0
   DestroyPersistentCharacter: 0
+--- !u!114 &6681311028336639718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2461370457626985535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5a906a3ed6f6416fbb0d5bd4e2bd1d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lobbiesContainer: {fileID: 2269567885505166013}
+  lobbyItemPrefab: {fileID: 6431237631302165411, guid: 13e64695dc3a44037a7a7568727079c6,
+    type: 3}
+  noLobbiesText: {fileID: 8723296149733053187}
 --- !u!1 &2734577476813917642
 GameObject:
   m_ObjectHideFlags: 0
@@ -7124,18 +7141,6 @@ MonoBehaviour:
       - m_Target: {fileID: 580734115480870141}
         m_TargetAssemblyTypeName: LobbiesManager, Assembly-CSharp
         m_MethodName: Refresh
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 7258747061359327656}
-        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
-        m_MethodName: RefreshLobbiesList
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/client/Assets/Prefabs/UI/ErrorCanvas.prefab
+++ b/client/Assets/Prefabs/UI/ErrorCanvas.prefab
@@ -741,10 +741,10 @@ MonoBehaviour:
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -1219,6 +1219,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8527848005455240905}
         m_TargetAssemblyTypeName: Errors, Assembly-CSharp
@@ -1232,16 +1235,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 8866022345268012935}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -1364,6 +1376,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8527848005455240905}
         m_TargetAssemblyTypeName: Errors, Assembly-CSharp
@@ -1377,16 +1392,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 5388493080288571147}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}
@@ -2517,6 +2541,9 @@ MonoBehaviour:
   Interactable: 1
   ButtonPressedFirstTime:
     m_PersistentCalls:
+      m_Calls: []
+  ButtonReleased:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8527848005455240905}
         m_TargetAssemblyTypeName: Errors, Assembly-CSharp
@@ -2530,16 +2557,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls: []
+      - m_Target: {fileID: 8589421836849372637}
+        m_TargetAssemblyTypeName: MoreMountains.Tools.MMTouchButton, MoreMountains.Tools
+        m_MethodName: DisableButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   ButtonPressed:
     m_PersistentCalls:
       m_Calls: []
-  DisabledSprite: {fileID: 0}
+  DisabledSprite: {fileID: 21300000, guid: af4b0e28fd9e04baaa4d6b123dffab75, type: 3}
   DisabledChangeColor: 0
   DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-  PressedSprite: {fileID: 0}
+  PressedSprite: {fileID: 21300000, guid: 122ba202a51764dfcb12fc730ded9515, type: 3}
   PressedChangeColor: 0
   PressedColor: {r: 1, g: 1, b: 1, a: 1}
   HighlightedSprite: {fileID: 0}

--- a/client/Assets/Scenes/Lobbies.unity
+++ b/client/Assets/Scenes/Lobbies.unity
@@ -123,12 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!224 &55917243 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2269567885505166013, guid: 108d83700d59547d0974e1d2edaf0140,
-    type: 3}
-  m_PrefabInstance: {fileID: 579426447}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &334993176
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -154,7 +148,7 @@ PrefabInstance:
     - target: {fileID: 5376578583088809355, guid: 74e8f34655b5949b69f18c0ed42a7d46,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5376578583088809355, guid: 74e8f34655b5949b69f18c0ed42a7d46,
         type: 3}
@@ -596,7 +590,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &631924962
 MonoBehaviour:
@@ -728,12 +722,6 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
---- !u!1 &1162332321 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8723296149733053187, guid: 108d83700d59547d0974e1d2edaf0140,
-    type: 3}
-  m_PrefabInstance: {fileID: 579426447}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1710169852
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -744,7 +732,7 @@ PrefabInstance:
     - target: {fileID: 4750655737416933824, guid: 992086b6c81f1425f8a67131ebd41cdd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4750655737416933824, guid: 992086b6c81f1425f8a67131ebd41cdd,
         type: 3}
@@ -803,80 +791,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 992086b6c81f1425f8a67131ebd41cdd, type: 3}
---- !u!1001 &4276914181274294756
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 88203665, guid: f9233336a14f14185abdb012364ffd92, type: 3}
-      propertyPath: noLobbiesText
-      value: 
-      objectReference: {fileID: 1162332321}
-    - target: {fileID: 88203665, guid: f9233336a14f14185abdb012364ffd92, type: 3}
-      propertyPath: lobbiesContainer
-      value: 
-      objectReference: {fileID: 55917243}
-    - target: {fileID: 4276914180947046944, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_Name
-      value: UIController
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -7.9636
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.666348
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4276914180947046946, guid: f9233336a14f14185abdb012364ffd92,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f9233336a14f14185abdb012364ffd92, type: 3}

--- a/client/Assets/Scripts/LobbiesManager.cs
+++ b/client/Assets/Scripts/LobbiesManager.cs
@@ -40,7 +40,6 @@ public class LobbiesManager : LevelSelector
     public void Refresh()
     {
         LobbyConnection.Instance.Refresh();
-        SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
 
     public void QuickGame()

--- a/client/Assets/Scripts/LobbiesManager.cs
+++ b/client/Assets/Scripts/LobbiesManager.cs
@@ -40,6 +40,7 @@ public class LobbiesManager : LevelSelector
     public void Refresh()
     {
         LobbyConnection.Instance.Refresh();
+        this.GetComponent<UIManager>().RefreshLobbiesList();
     }
 
     public void QuickGame()

--- a/client/Assets/Scripts/UIManager.cs
+++ b/client/Assets/Scripts/UIManager.cs
@@ -14,7 +14,6 @@ public class UIManager : MonoBehaviour
 
     [SerializeField]
     GameObject noLobbiesText;
-    List<string> lobbiesList;
 
     void Start()
     {
@@ -47,8 +46,7 @@ public class UIManager : MonoBehaviour
 
     void GenerateList()
     {
-        lobbiesList = new List<string>();
-        lobbiesList = LobbyConnection.Instance.lobbiesList;
+        List<string> lobbiesList = LobbyConnection.Instance.lobbiesList;
         lobbiesList.Reverse();
         lobbiesList.ForEach(el =>
         {

--- a/client/Assets/Scripts/UIManager.cs
+++ b/client/Assets/Scripts/UIManager.cs
@@ -16,32 +16,48 @@ public class UIManager : MonoBehaviour
     GameObject noLobbiesText;
 
     bool lobbiesEmpty = true;
-    bool gamesEmpty = true;
+    public List<string> lobbiesList;
+    private IEnumerator init;
 
     void Start()
     {
         noLobbiesText.SetActive(lobbiesEmpty);
+        init = InitializeList();
+        StartCoroutine(init);
     }
 
-    // Update is called once per frame
-    void Update()
+    private IEnumerator InitializeList()
     {
-        if (lobbiesEmpty && LobbyConnection.Instance.lobbiesList.Count > 0)
-        {
-            noLobbiesText.SetActive(false);
-            GenerateList(LobbyConnection.Instance.lobbiesList, lobbyItemPrefab, lobbiesContainer);
-            lobbiesEmpty = false;
-        }
+        yield return new WaitUntil(() => LobbyConnection.Instance.lobbiesList.Count > 0);
+        GenerateList();
+        Debug.Log("hi");
     }
 
-    public void GenerateList(List<string> itemList, Object itemPrefab, Transform container)
+    void GenerateList()
     {
-        itemList.Reverse();
-        itemList.ForEach(el =>
+        lobbiesList = new List<string>();
+        lobbiesList = LobbyConnection.Instance.lobbiesList;
+
+        noLobbiesText.SetActive(false);
+        lobbiesList.Reverse();
+        lobbiesList.ForEach(el =>
         {
-            GameObject item = (GameObject)Instantiate(itemPrefab, container);
+            GameObject item = (GameObject)Instantiate(lobbyItemPrefab, lobbiesContainer);
             string lastCharactersInID = el.Substring(el.Length - 5);
             item.GetComponent<LobbiesListItem>().setId(el, lastCharactersInID);
+        });
+        lobbiesEmpty = false;
+    }
+
+    public void RefreshLobbiesList()
+    {
+        init = InitializeList();
+        StartCoroutine(init);
+        List<LobbiesListItem> lobbyItems = new List<LobbiesListItem>();
+        lobbyItems.AddRange(lobbiesContainer.GetComponentsInChildren<LobbiesListItem>());
+        lobbyItems.ForEach(lobbyItem =>
+        {
+            Destroy(lobbyItem.gameObject);
         });
     }
 }

--- a/client/Assets/Scripts/UIManager.cs
+++ b/client/Assets/Scripts/UIManager.cs
@@ -14,31 +14,41 @@ public class UIManager : MonoBehaviour
 
     [SerializeField]
     GameObject noLobbiesText;
-
-    bool lobbiesEmpty = true;
-    public List<string> lobbiesList;
-    private IEnumerator init;
+    List<string> lobbiesList;
 
     void Start()
     {
-        noLobbiesText.SetActive(lobbiesEmpty);
-        init = InitializeList();
-        StartCoroutine(init);
+        SetEmptyListIndicator(true);
+        StartCoroutine(InitializeList());
     }
 
     private IEnumerator InitializeList()
     {
-        yield return new WaitUntil(() => LobbyConnection.Instance.lobbiesList.Count > 0);
+        yield return new WaitForSeconds(0.5f);
+        SetEmptyListIndicator(LobbyConnection.Instance.lobbiesList.Count == 0);
+        EmptyList();
         GenerateList();
-        Debug.Log("hi");
+    }
+
+    void SetEmptyListIndicator(bool state)
+    {
+        noLobbiesText.SetActive(state);
+    }
+
+    void EmptyList()
+    {
+        List<LobbiesListItem> lobbyItems = new List<LobbiesListItem>();
+        lobbyItems.AddRange(lobbiesContainer.GetComponentsInChildren<LobbiesListItem>());
+        lobbyItems.ForEach(lobbyItem =>
+        {
+            Destroy(lobbyItem.gameObject);
+        });
     }
 
     void GenerateList()
     {
         lobbiesList = new List<string>();
         lobbiesList = LobbyConnection.Instance.lobbiesList;
-
-        noLobbiesText.SetActive(false);
         lobbiesList.Reverse();
         lobbiesList.ForEach(el =>
         {
@@ -46,18 +56,10 @@ public class UIManager : MonoBehaviour
             string lastCharactersInID = el.Substring(el.Length - 5);
             item.GetComponent<LobbiesListItem>().setId(el, lastCharactersInID);
         });
-        lobbiesEmpty = false;
     }
 
     public void RefreshLobbiesList()
     {
-        init = InitializeList();
-        StartCoroutine(init);
-        List<LobbiesListItem> lobbyItems = new List<LobbiesListItem>();
-        lobbyItems.AddRange(lobbiesContainer.GetComponentsInChildren<LobbiesListItem>());
-        lobbyItems.ForEach(lobbyItem =>
-        {
-            Destroy(lobbyItem.gameObject);
-        });
+        StartCoroutine(InitializeList());
     }
 }


### PR DESCRIPTION
This PR solves issues #664 and #779 
It optimizes the way we refresh our lobbies list and changes the buttons styles (in lobbies scene) to fix ui and ux problems.

Issues to check if they were solved:
- Hold your finger in the Refresh button. It should no longer refresh constantly. Instead, it should refresh when you stop pressing on it.
- If you press the Refresh button it should no longer toggle as much between the empty list indicator and the lobbies. Instead it should show either one or the other until your next refresh. 
_Two things to take into account: now it may not show you a lobby if it took too long to fetch it. That is expected and it works like that in other games too. In that case you should refresh again; If you spam the Refresh button it may occur that a lobby list is shown after an empty list indicator. This is also expected behavior._
- If an error is shown after or while a button is pressed, your buttons should no longer stay in a pressed state.
_You can trigger a pop up to test this by starting a game with a different hash to trigger a warning or pressing the server button and display the server options_

_Keep in mind the button changes were only made in the lobbies scene since a refactor of buttons styles is coming up_
