### PR TITLE
Enable Uma's forced rotation

### DIFF
--- a/client/Assets/Prefabs/Characters/Uma.prefab
+++ b/client/Assets/Prefabs/Characters/Uma.prefab
@@ -216,8 +216,8 @@ MonoBehaviour:
   LockVerticalRotation: 1
   RotationSpeedResetSpeed: 2
   RotationOffsetSmoothSpeed: 1
-  ForcedRotation: 0
-  ForcedRotationDirection: {x: 0, y: 0, z: 0}
+  ForcedRotation: 1
+  ForcedRotationDirection: {x: 1, y: 0, z: 1}
 --- !u!114 &1787465996332106806
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Closes #925 

In Uma's Character Orientation 3D component, Forced Rotation was disabled, causing problems when trying to rotate the character without moving it first at the beginning of a new match.