### PR TITLE
Fix zone timer on reconnect

### DIFF
--- a/client/Assets/Scripts/LobbyConnection.cs
+++ b/client/Assets/Scripts/LobbyConnection.cs
@@ -38,6 +38,9 @@ public class LobbyConnection : MonoBehaviour
     public string reconnectServerHash;
     public string reconnectGameId;
     public ulong reconnectPlayerId;
+
+    public DateTime matchStarted;
+
     public Dictionary<ulong, string> reconnectPlayers;
     public ServerGameSettings reconnectServerSettings;
 
@@ -236,6 +239,7 @@ public class LobbyConnection : MonoBehaviour
         this.serverHash = this.reconnectServerHash;
         this.playerCount = this.reconnectPlayerCount;
         this.gameStarted = true;
+        this.matchStarted = DateTime.Parse(PlayerPrefs.GetString("matchStartTime"));
     }
 
     private IEnumerator WaitLobbyCreated()
@@ -352,6 +356,7 @@ public class LobbyConnection : MonoBehaviour
                         this.reconnectServerSettings = parseReconnectServerSettings(
                             response.game_config
                         );
+
                         Errors.Instance.HandleReconnectError(
                             ongoingGameTitle,
                             ongoingGameDescription

--- a/client/Assets/Scripts/LobbyConnection.cs
+++ b/client/Assets/Scripts/LobbyConnection.cs
@@ -38,9 +38,7 @@ public class LobbyConnection : MonoBehaviour
     public string reconnectServerHash;
     public string reconnectGameId;
     public ulong reconnectPlayerId;
-
-    public DateTime matchStarted;
-
+    public ulong matchStartTime;
     public Dictionary<ulong, string> reconnectPlayers;
     public ServerGameSettings reconnectServerSettings;
 
@@ -239,7 +237,7 @@ public class LobbyConnection : MonoBehaviour
         this.serverHash = this.reconnectServerHash;
         this.playerCount = this.reconnectPlayerCount;
         this.gameStarted = true;
-        this.matchStarted = DateTime.Parse(PlayerPrefs.GetString("matchStartTime"));
+        this.matchStartTime = Convert.ToUInt64(PlayerPrefs.GetString("matchStartTime"));
     }
 
     private IEnumerator WaitLobbyCreated()

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -163,6 +163,11 @@ public class SocketConnectionManager : MonoBehaviour
                     this.gameProjectiles = gameEvent.Projectiles.ToList();
                     alivePlayers = gameEvent.Players.ToList().FindAll(el => el.Health > 0);
                     updatedLoots = gameEvent.Loots.ToList();
+
+                    if(LobbyConnection.Instance.matchStartTime == 0) {
+                        LobbyConnection.Instance.matchStartTime = (ulong)gameEvent.ServerTimestamp;
+                        PlayerPrefs.SetString("matchStartTime", ((ulong)gameEvent.ServerTimestamp).ToString());
+                    }
                     break;
                 case GameEventType.PingUpdate:
                     currentPing = (uint)gameEvent.Latency;
@@ -186,8 +191,6 @@ public class SocketConnectionManager : MonoBehaviour
                     );
                     this.allSelected = true;
                     this.gamePlayers = gameEvent.Players.ToList();
-                    LobbyConnection.Instance.matchStarted = DateTime.Now;
-                    PlayerPrefs.SetString("matchStartTime", DateTime.Now.ToString());
                     break;
                 default:
                     print("Message received is: " + gameEvent.Type);

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -186,6 +186,8 @@ public class SocketConnectionManager : MonoBehaviour
                     );
                     this.allSelected = true;
                     this.gamePlayers = gameEvent.Players.ToList();
+                    LobbyConnection.Instance.matchStarted = DateTime.Now;
+                    PlayerPrefs.SetString("matchStartTime", DateTime.Now.ToString());
                     break;
                 default:
                     print("Message received is: " + gameEvent.Type);

--- a/client/Assets/Scripts/UI/MatchStatsController.cs
+++ b/client/Assets/Scripts/UI/MatchStatsController.cs
@@ -33,14 +33,10 @@ public class MatchStatsController : MonoBehaviour
                 .serverSettings
                 .RunnerConfig
                 .MapShrinkWaitMs;
-            if(mapShrinkWaitMs > elapsedTime) {
-                remainingSeconds = (mapShrinkWaitMs - elapsedTime) / 1000;
-                zoneTimer.text = remainingSeconds.ToString();
-            }
-            else {
-                remainingSeconds = 0;
-                zoneTimer.text = "0";
-            }
+            remainingSeconds = (mapShrinkWaitMs > elapsedTime) ?
+                (mapShrinkWaitMs - elapsedTime) / 1000
+                : 0;
+            zoneTimer.text = remainingSeconds.ToString();
         }
     }
 }

--- a/client/Assets/Scripts/UI/MatchStatsController.cs
+++ b/client/Assets/Scripts/UI/MatchStatsController.cs
@@ -39,13 +39,7 @@ public class MatchStatsController : MonoBehaviour
             .GetGamePlayer(SocketConnectionManager.Instance.playerId)
             ?.KillCount.ToString();
 
-        time += Time.deltaTime;
-
-        if (time >= period && seconds > 0)
-        {
-            time = time - period;
-            seconds--;
-            zoneTimer.text = seconds.ToString();
-        }
+        ulong timeRemainingMilliseconds = (ulong)(LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs - (DateTime.Now - LobbyConnection.Instance.matchStarted).TotalMilliseconds);
+        zoneTimer.text = (timeRemainingMilliseconds / 1000).ToString();
     }
 }

--- a/client/Assets/Scripts/UI/MatchStatsController.cs
+++ b/client/Assets/Scripts/UI/MatchStatsController.cs
@@ -15,22 +15,8 @@ public class MatchStatsController : MonoBehaviour
 
     [SerializeField]
     TextMeshProUGUI killCount;
-    private float nextActionTime = 0.0f;
-    public float period = 1f;
 
-    public float time = 0f;
-
-    ulong seconds = 0;
-
-    void Awake()
-    {
-        seconds = LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs / 1000;
-    }
-
-    void Start()
-    {
-        zoneTimer.text = seconds.ToString();
-    }
+    ulong remainingSeconds = 1;
 
     void FixedUpdate()
     {
@@ -39,9 +25,17 @@ public class MatchStatsController : MonoBehaviour
             .GetGamePlayer(SocketConnectionManager.Instance.playerId)
             ?.KillCount.ToString();
 
-        EventsBuffer buffer = SocketConnectionManager.Instance.eventsBuffer;
-        ulong elapsedTime = (ulong)buffer.lastEvent().ServerTimestamp - LobbyConnection.Instance.matchStartTime;
-        ulong timeRemainingMilliseconds = LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs - elapsedTime;
-        zoneTimer.text = (timeRemainingMilliseconds / 1000).ToString();
+        if(remainingSeconds > 0) {
+            EventsBuffer buffer = SocketConnectionManager.Instance.eventsBuffer;
+            ulong elapsedTime = (ulong)buffer.lastEvent().ServerTimestamp - LobbyConnection.Instance.matchStartTime;
+            if(LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs > elapsedTime) {
+                remainingSeconds = (LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs - elapsedTime) / 1000;
+                zoneTimer.text = remainingSeconds.ToString();
+            }
+            else {
+                remainingSeconds = 0;
+                zoneTimer.text = "0";
+            }
+        }
     }
 }

--- a/client/Assets/Scripts/UI/MatchStatsController.cs
+++ b/client/Assets/Scripts/UI/MatchStatsController.cs
@@ -39,7 +39,9 @@ public class MatchStatsController : MonoBehaviour
             .GetGamePlayer(SocketConnectionManager.Instance.playerId)
             ?.KillCount.ToString();
 
-        ulong timeRemainingMilliseconds = (ulong)(LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs - (DateTime.Now - LobbyConnection.Instance.matchStarted).TotalMilliseconds);
+        EventsBuffer buffer = SocketConnectionManager.Instance.eventsBuffer;
+        ulong elapsedTime = (ulong)buffer.lastEvent().ServerTimestamp - LobbyConnection.Instance.matchStartTime;
+        ulong timeRemainingMilliseconds = LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs - elapsedTime;
         zoneTimer.text = (timeRemainingMilliseconds / 1000).ToString();
     }
 }

--- a/client/Assets/Scripts/UI/MatchStatsController.cs
+++ b/client/Assets/Scripts/UI/MatchStatsController.cs
@@ -28,8 +28,13 @@ public class MatchStatsController : MonoBehaviour
         if(remainingSeconds > 0) {
             EventsBuffer buffer = SocketConnectionManager.Instance.eventsBuffer;
             ulong elapsedTime = (ulong)buffer.lastEvent().ServerTimestamp - LobbyConnection.Instance.matchStartTime;
-            if(LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs > elapsedTime) {
-                remainingSeconds = (LobbyConnection.Instance.serverSettings.RunnerConfig.MapShrinkWaitMs - elapsedTime) / 1000;
+            ulong mapShrinkWaitMs = LobbyConnection
+                .Instance
+                .serverSettings
+                .RunnerConfig
+                .MapShrinkWaitMs;
+            if(mapShrinkWaitMs > elapsedTime) {
+                remainingSeconds = (mapShrinkWaitMs - elapsedTime) / 1000;
                 zoneTimer.text = remainingSeconds.ToString();
             }
             else {


### PR DESCRIPTION
Registered the start time of the match, calculate based on that the time elapsed since the beginning of it, subtract from the time it takes to start shrinking the zone the time elapsed and display it.

Closes #818 