### PR TITLE
Fix kill cam

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -373,26 +373,18 @@ public class CustomLevelManager : LevelManager
 
     private void SetCameraToAlivePlayer()
     {
-        playerToFollow = Utils.GetGamePlayer(KillFeedManager.instance.playerToTrack);
-        if (KillFeedManager.instance.saveKillerId != 0)
-        {
-            StartCoroutine(WaitToChangeCamera(playerToFollow));
-        }
-        else
-        {
-            if (playerToFollow.Status == Status.Dead && Utils.GetAlivePlayers().Count() > 0)
-            {
-                playerToFollow = Utils.GetAlivePlayers().ElementAt(0);
-                setCameraToPlayer(playerToFollow.Id);
-            }
-        }
+        playerToFollow =
+            KillFeedManager.instance.killedByDangerZone == true
+                ? playerToFollow = Utils.GetAlivePlayers().ElementAt(0)
+                : Utils.GetGamePlayer(KillFeedManager.instance.playerToTrack);
+
+        StartCoroutine(WaitToChangeCamera(playerToFollow));
     }
 
     private IEnumerator WaitToChangeCamera(Player player)
     {
         yield return new WaitUntil(() => player != null);
         setCameraToPlayer(playerToFollow.Id);
-        KillFeedManager.instance.saveKillerId = 0;
     }
 
     private bool GameHasEndedOrPlayerHasDied(Player gamePlayer)

--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -378,7 +378,13 @@ public class CustomLevelManager : LevelManager
         {
             StartCoroutine(WaitToChangeCamera(playerToFollow));
         }
-        if ((playerToFollow.Status == Status.Dead && KillFeedManager.instance.saveKillerId == 0))
+        if (
+            (
+                playerToFollow.Status == Status.Dead
+                && KillFeedManager.instance.saveKillerId == 0
+                && Utils.GetAlivePlayers().Count() > 0
+            )
+        )
         {
             playerToFollow = Utils.GetAlivePlayers().ElementAt(0);
             setCameraToPlayer(playerToFollow.Id);

--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -374,20 +374,17 @@ public class CustomLevelManager : LevelManager
     private void SetCameraToAlivePlayer()
     {
         playerToFollow = Utils.GetGamePlayer(KillFeedManager.instance.playerToTrack);
-        if (playerToFollow != null)
+        if (KillFeedManager.instance.saveKillerId != 0)
         {
             StartCoroutine(WaitToChangeCamera(playerToFollow));
         }
-        if (
-            (
-                playerToFollow.Status == Status.Dead
-                && KillFeedManager.instance.saveKillerId == 0
-                && Utils.GetAlivePlayers().Count() > 0
-            )
-        )
+        else
         {
-            playerToFollow = Utils.GetAlivePlayers().ElementAt(0);
-            setCameraToPlayer(playerToFollow.Id);
+            if (playerToFollow.Status == Status.Dead && Utils.GetAlivePlayers().Count() > 0)
+            {
+                playerToFollow = Utils.GetAlivePlayers().ElementAt(0);
+                setCameraToPlayer(playerToFollow.Id);
+            }
         }
     }
 

--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -373,12 +373,13 @@ public class CustomLevelManager : LevelManager
 
     private void SetCameraToAlivePlayer()
     {
-        playerToFollow = Utils.GetGamePlayer(KillFeedManager.instance.saveKillerId);
-        if (KillFeedManager.instance.saveKillerId != 0)
+        playerToFollow = Utils.GetGamePlayer(KillFeedManager.instance.playerToTrack);
+        print(KillFeedManager.instance.saveKillerId);
+        if (playerToFollow != null)
         {
             StartCoroutine(WaitToChangeCamera(playerToFollow));
         }
-        else
+        if ((playerToFollow.Status == Status.Dead && KillFeedManager.instance.saveKillerId == 0))
         {
             playerToFollow = Utils.GetAlivePlayers().ElementAt(0);
             setCameraToPlayer(playerToFollow.Id);

--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -374,7 +374,6 @@ public class CustomLevelManager : LevelManager
     private void SetCameraToAlivePlayer()
     {
         playerToFollow = Utils.GetGamePlayer(KillFeedManager.instance.playerToTrack);
-        print(KillFeedManager.instance.saveKillerId);
         if (playerToFollow != null)
         {
             StartCoroutine(WaitToChangeCamera(playerToFollow));

--- a/client/Assets/Scripts/UI/KillFeedManager.cs
+++ b/client/Assets/Scripts/UI/KillFeedManager.cs
@@ -15,15 +15,32 @@ public class KillFeedManager : MonoBehaviour
 
     public ulong playerToTrack;
 
+    public bool killedByDangerZone = false;
+
+    public List<ulong> killedRegistrations = new List<ulong>();
+
     public void Awake()
     {
         KillFeedManager.instance = this;
         playerToTrack = SocketConnectionManager.Instance.playerId;
+        killedRegistrations.Add(9999);
     }
 
     public void putEvents(List<KillEvent> feedEvent)
     {
-        feedEvent.ForEach((killEvent) => feedEvents.Enqueue(killEvent));
+        feedEvent.ForEach(
+            (killEvent) =>
+            {
+                feedEvents.Enqueue(killEvent);
+                killedRegistrations.Add(killEvent.Killed);
+            }
+        );
+        bool dead = Utils.GetGamePlayer(playerToTrack).Status == Status.Dead;
+        killedRegistrations.ForEach(el => print(el));
+        if (dead)
+        {
+            killedByDangerZone = killedRegistrations.Find(el => el == playerToTrack) == 0;
+        }
     }
 
     public ulong GetKiller(ulong deathPlayerId)
@@ -44,8 +61,7 @@ public class KillFeedManager : MonoBehaviour
         {
             if (playerToTrack == killEvent.Killed)
             {
-                saveKillerId = killEvent.KilledBy;
-                playerToTrack = saveKillerId;
+                playerToTrack = killEvent.KilledBy;
             }
             killFeedItem.SetPlayerNames(killEvent.KilledBy.ToString(), killEvent.Killed.ToString());
             GameObject item = Instantiate(killFeedItem.gameObject, transform);


### PR DESCRIPTION
This PR fixes the killcam. It uses the killfeed messages to find the correct player to follow.

To test:

- If you get killed by a player the camera should spectate that player.
- If you get killed by the danger zone you should spectate the first player alive in the list ( ex: player1 )

This PR patches the problem that the backend doesn't send any msg if you get killed by the danger zone, so are doing the following:

- Check if the player following is DEAD
- Check if there is no KilledBy event
- Result : you get killed by the dangerZone

DISCLAIMER:
`killedRegistrations.Add(9999);` I hate this line but it was necessary for the patch. I will implement the backend version detailed in this #636 and this will be deleted!