### PR TITLE
Fix Danger zone UI

### DIFF
--- a/client/Assets/Scripts/Battle.cs
+++ b/client/Assets/Scripts/Battle.cs
@@ -633,8 +633,11 @@ public class Battle : MonoBehaviour
         playerCharacter.CharacterModel.SetActive(false);
         playerCharacter.ConditionState.ChangeState(CharacterStates.CharacterConditions.Dead);
         playerCharacter.characterBase.Hitbox.SetActive(false);
-        CustomGUIManager.DisplayZoneDamageFeedback(false);
         levelManager.DestroySkillsClone(playerCharacter);
+        if (SocketConnectionManager.Instance.playerId == ulong.Parse(playerCharacter.PlayerID))
+        {
+            CustomGUIManager.DisplayZoneDamageFeedback(false);
+        }
     }
 
     // CLIENT PREDICTION UTILITY FUNCTIONS , WE USE THEM IN THE MMTOUCHBUTTONS OF THE PAUSE SPLASH
@@ -824,7 +827,10 @@ public class Battle : MonoBehaviour
             }
         }
 
-        if (SocketConnectionManager.Instance.playerId == playerUpdate.Id)
+        if (
+            SocketConnectionManager.Instance.playerId == playerUpdate.Id
+            && playerUpdate.Status == Status.Alive
+        )
         {
             if (playerUpdate.Effects.ContainsKey((ulong)PlayerEffect.OutOfArea))
             {


### PR DESCRIPTION
The problem:
- The Danger zone UI sometimes was not appearing correctly.

What happened ?
- When someone die a method called `SetPlayerDead` in `Battle.cs` called  `CustomGUIManager.DisplayZoneDamageFeedback(false);` causing the bug

The Fix:

- We only want to desactivate the zone effects if we are dead and it is in our client, so:
	```
	if (SocketConnectionManager.Instance.playerId == ulong.Parse(playerCharacter.PlayerID))
	    {
	            CustomGUIManager.DisplayZoneDamageFeedback(false);
	     }
	```

closes #1047 