### PR TITLE
Add bot wandering

### DIFF
--- a/server/lib/dark_worlds_server/engine/bot_player.ex
+++ b/server/lib/dark_worlds_server/engine/bot_player.ex
@@ -49,7 +49,8 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     send(self(), {:decide_action, bot_id})
     send(self(), {:do_action, bot_id})
 
-    {:noreply, put_in(state, [:bots, bot_id], %{alive: true, objective: :random_movement})}
+
+    {:noreply, put_in(state, [:bots, bot_id], %{alive: true, objective: :nothing, current_wandering_position: nil})}
   end
 
   def handle_cast({:bots_enabled, toggle}, state) do
@@ -122,9 +123,20 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     Map.put(bot_state, :action, :die)
   end
 
-  defp decide_action(%{objective: :random_movement} = bot_state, _bot_id, _players, _game_state, _closest_entity) do
-    movement = Enum.random([{1.0, 1.0}, {-1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}, {0.0, 0.0}])
-    Map.put(bot_state, :action, {:move, movement})
+  defp decide_action(%{objective: :wander, current_wandering_position: wandering_position} = bot_state, bot_id, players, _game_state, _closest_entity) do
+    bot = Enum.find(players, fn player -> player.id == bot_id end)
+
+    if bot do
+      target =
+        calculate_circle_point(
+          bot.position,
+          wandering_position
+        )
+
+      Map.put(bot_state, :action, {:move, target})
+    else
+      Map.put(bot_state, :action, {:nothing, nil})
+    end
   end
 
   defp decide_action(%{objective: :attack_enemy} = bot_state, _bot_id, _players, _game_state, closest_entity) do
@@ -218,11 +230,15 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
               :attack_enemy
 
             true ->
-              :random_movement
+              :wander
           end
       end
 
-    Map.put(bot_state, :objective, objective)
+    if objective == :wander do
+      maybe_put_wandering_position(bot_state, bot, myrra_state)
+    else
+      Map.put(bot_state, :objective, objective)
+    end
   end
 
   def decide_objective(bot_state, _, _, _), do: Map.put(bot_state, :objective, :nothing)
@@ -290,5 +306,57 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     end)
     |> Enum.sort_by(fn distances -> distances.distance_to_entity end, :asc)
     |> Enum.filter(fn distances -> distances.distance_to_entity <= @visibility_max_range_cells end)
+  end
+
+  def maybe_put_wandering_position(
+    %{objective: :wander, current_wandering_position: current_wandering_position} = bot_state,
+    bot,
+    myrra_state
+  ) do
+    if get_distance_to_point(bot.position, %Position{x: current_wandering_position.x, y: current_wandering_position.y}) <
+        500 do
+      put_wandering_position(bot_state, bot, myrra_state)
+    else
+      bot_state
+    end
+  end
+
+  def maybe_put_wandering_position(bot_state, bot, myrra_state),
+    do: put_wandering_position(bot_state, bot, myrra_state)
+
+  def put_wandering_position(
+    bot_state,
+    %{position: bot_position},
+    myrra_state
+  ) do
+    bot_visibility_radius = @visibility_max_range_cells * 2
+
+    # We need to pick and X and Y wich are in a safe zone close to the bot that's also inside of the board
+    left_x =
+      Enum.max([myrra_state.shrinking_center.x - myrra_state.playable_radius, bot_position.x - bot_visibility_radius, 0])
+
+    right_x =
+      Enum.min([
+        myrra_state.shrinking_center.x + myrra_state.playable_radius,
+        bot_position.x + bot_visibility_radius,
+        myrra_state.board.width
+      ])
+
+    down_y =
+      Enum.max([myrra_state.shrinking_center.y - myrra_state.playable_radius, bot_position.y - bot_visibility_radius, 0])
+
+    up_y =
+      Enum.min([
+        myrra_state.shrinking_center.y + myrra_state.playable_radius,
+        bot_position.y + bot_visibility_radius,
+        myrra_state.board.height
+      ])
+
+    wandering_position = %{
+      x: Enum.random(left_x..right_x),
+      y: Enum.random(down_y..up_y)
+    }
+
+    Map.merge(bot_state, %{current_wandering_position: wandering_position, objective: :wander})
   end
 end

--- a/server/lib/dark_worlds_server/engine/bot_player.ex
+++ b/server/lib/dark_worlds_server/engine/bot_player.ex
@@ -4,7 +4,6 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   alias DarkWorldsServer.Communication
   alias DarkWorldsServer.Engine.ActionOk
   alias DarkWorldsServer.Engine.Runner
-  alias LambdaGameEngine.MyrraEngine.Position
   alias LambdaGameEngine.MyrraEngine.RelativePosition
 
   # This variable will decide how much time passes between bot decisions in milis

--- a/server/lib/dark_worlds_server/engine/bot_player.ex
+++ b/server/lib/dark_worlds_server/engine/bot_player.ex
@@ -49,7 +49,6 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     send(self(), {:decide_action, bot_id})
     send(self(), {:do_action, bot_id})
 
-
     {:noreply, put_in(state, [:bots, bot_id], %{alive: true, objective: :nothing, current_wandering_position: nil})}
   end
 
@@ -123,7 +122,13 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     Map.put(bot_state, :action, :die)
   end
 
-  defp decide_action(%{objective: :wander, current_wandering_position: wandering_position} = bot_state, bot_id, players, _game_state, _closest_entity) do
+  defp decide_action(
+         %{objective: :wander, current_wandering_position: wandering_position} = bot_state,
+         bot_id,
+         players,
+         _game_state,
+         _closest_entity
+       ) do
     bot = Enum.find(players, fn player -> player.id == bot_id end)
 
     if bot do
@@ -282,7 +287,7 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     %{}
   end
 
-  defp get_distance_to_point(%Position{x: start_x, y: start_y}, %Position{x: end_x, y: end_y}) do
+  defp get_distance_to_point(%{x: start_x, y: start_y}, %{x: end_x, y: end_y}) do
     diagonal_movement_cost = 14
     straight_movement_cost = 10
 
@@ -309,12 +314,12 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   end
 
   def maybe_put_wandering_position(
-    %{objective: :wander, current_wandering_position: current_wandering_position} = bot_state,
-    bot,
-    myrra_state
-  ) do
-    if get_distance_to_point(bot.position, %Position{x: current_wandering_position.x, y: current_wandering_position.y}) <
-        500 do
+        %{objective: :wander, current_wandering_position: current_wandering_position} = bot_state,
+        bot,
+        myrra_state
+      ) do
+    if get_distance_to_point(bot.position, %{x: current_wandering_position.x, y: current_wandering_position.y}) <
+         500 do
       put_wandering_position(bot_state, bot, myrra_state)
     else
       bot_state
@@ -325,10 +330,10 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
     do: put_wandering_position(bot_state, bot, myrra_state)
 
   def put_wandering_position(
-    bot_state,
-    %{position: bot_position},
-    myrra_state
-  ) do
+        bot_state,
+        %{position: bot_position},
+        myrra_state
+      ) do
     bot_visibility_radius = @visibility_max_range_cells * 2
 
     # We need to pick and X and Y wich are in a safe zone close to the bot that's also inside of the board


### PR DESCRIPTION
This pr is part of #709 

The bots should pick a random location in the playable area (inside the zone) and walk to it now, they can get distracted if they come across a player of loot crate on their way

To pick their next wander position the posible destinations should meet the next requirements:
- Be inside of the bot visibility zone
- Be inside of the board
- Be inside of the safe zone

i'll attach some examples of possible destinations:
<img width="764" alt="Screenshot 2023-10-26 at 12 51 56" src="https://github.com/lambdaclass/curse_of_myrra/assets/106101218/ba5b55f2-3e75-43ea-9b9a-6a188611c7c9">
<img width="656" alt="Screenshot 2023-10-26 at 12 52 44" src="https://github.com/lambdaclass/curse_of_myrra/assets/106101218/7046a440-8fc8-4f89-b43a-4a9bfd5841ad">
<img width="566" alt="Screenshot 2023-10-26 at 12 53 13" src="https://github.com/lambdaclass/curse_of_myrra/assets/106101218/93ffa463-f00a-4460-a7fb-b7ba8aa624d7">
