### PR TITLE
[GH-956] Refactor current game flow

### DIFF
--- a/client/Assets/Scripts/LobbyConnection.cs
+++ b/client/Assets/Scripts/LobbyConnection.cs
@@ -171,7 +171,7 @@ public class LobbyConnection : MonoBehaviour
     public void CreateLobby()
     {
         ValidateVersionHashes();
-        StartCoroutine(GetRequest(makeUrl("/new_lobby")));
+        StartCoroutine(GetRequest(makeUrl("/join_lobby")));
     }
 
     public void ConnectToLobby(string matchmaking_id)

--- a/client/Assets/StreamingAssets/Skills.json
+++ b/client/Assets/StreamingAssets/Skills.json
@@ -1,6 +1,7 @@
 {
   "Items": [
     {
+      "Projectile": "",
       "Name": "Bash",
       "Cooldown": "500",
       "Damage": "12",
@@ -19,6 +20,7 @@
       "Angle": "140"
     },
     {
+      "Projectile": "",
       "Name": "Barrel Roll",
       "Cooldown": "5000",
       "Damage": "19",
@@ -37,6 +39,7 @@
       "Angle": "360"
     },
     {
+      "Projectile": "",
       "Name": "Rage",
       "Cooldown": "10000",
       "Damage": "0",
@@ -55,6 +58,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Leap",
       "Cooldown": "6000",
       "Damage": "12",
@@ -73,6 +77,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Fiery Rampage",
       "Cooldown": "20000",
       "Damage": "0",
@@ -91,6 +96,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Elnars Mark",
       "Cooldown": "900",
       "Damage": "20",
@@ -109,6 +115,7 @@
       "Angle": "360"
     },
     {
+      "Projectile": "",
       "Name": "Yugens Mark",
       "Cooldown": "4500",
       "Damage": "20",
@@ -127,6 +134,7 @@
       "Angle": "45"
     },
     {
+      "Projectile": "",
       "Name": "Xandas Mark",
       "Cooldown": "9000",
       "Damage": "0",
@@ -145,6 +153,7 @@
       "Angle": "360"
     },
     {
+      "Projectile": "",
       "Name": "Shadowstep",
       "Cooldown": "500",
       "Damage": "10",
@@ -163,6 +172,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Avenge",
       "Cooldown": "40000",
       "Damage": "0",
@@ -181,6 +191,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Slingshot",
       "Cooldown": "800",
       "Damage": "9",
@@ -199,6 +210,7 @@
       "Angle": "45"
     },
     {
+      "Projectile": "",
       "Name": "Multishot",
       "Cooldown": "4500",
       "Damage": "9",
@@ -217,6 +229,7 @@
       "Angle": "45"
     },
     {
+      "Projectile": "",
       "Name": "Disarm",
       "Cooldown": "6500",
       "Damage": "0",
@@ -235,6 +248,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Neon Crash",
       "Cooldown": "5000",
       "Damage": "3",
@@ -253,6 +267,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Denial of Service",
       "Cooldown": "20000",
       "Damage": "0",
@@ -271,6 +286,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Scherzo",
       "Cooldown": "0",
       "Damage": "10",
@@ -289,6 +305,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Pizzicato",
       "Cooldown": "4000",
       "Damage": "10",
@@ -307,6 +324,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Band Recruit",
       "Cooldown": "5000",
       "Damage": "10",
@@ -325,6 +343,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Danse Macabre",
       "Cooldown": "8000",
       "Damage": "10",
@@ -343,6 +362,7 @@
       "Angle": "0"
     },
     {
+      "Projectile": "",
       "Name": "Orchestra",
       "Cooldown": "60000",
       "Damage": "10",

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -69,9 +69,7 @@ config :logger, :console,
 config :phoenix, :json_library, Jason
 
 # Configures game GenServer
-config :dark_worlds_server, DarkWorldsServer.Engine.Runner,
-  process_priority: :high,
-  use_engine_runner: false
+config :dark_worlds_server, DarkWorldsServer.Engine.Runner, process_priority: :high
 
 # Configure server hash
 {hash, _} = System.cmd("git", ["rev-parse", "--short=8", "HEAD"])

--- a/server/lib/dark_worlds_server/engine/engine.ex
+++ b/server/lib/dark_worlds_server/engine/engine.ex
@@ -7,19 +7,19 @@ defmodule DarkWorldsServer.Engine do
   alias DarkWorldsServer.Engine.EngineRunner
   alias DarkWorldsServer.Engine.PlayerTracker
   alias DarkWorldsServer.Engine.RequestTracker
-  alias DarkWorldsServer.Engine.Runner
 
   def start_link(args) do
     DynamicSupervisor.start_link(__MODULE__, args, name: __MODULE__)
   end
 
-  def start_child(args) do
-    DynamicSupervisor.start_child(__MODULE__, {Runner, args})
-  end
+  def start_child() do
+    {:ok, engine_config_json} =
+      Application.app_dir(:lambda_game_engine, "priv/config.json") |> File.read()
 
-  def start_engine_runner() do
-    {:ok, engine_config_json} = Application.app_dir(:lambda_game_engine, "priv/config.json") |> File.read()
-    DynamicSupervisor.start_child(__MODULE__, {EngineRunner, %{engine_config_raw_json: engine_config_json}})
+    DynamicSupervisor.start_child(
+      __MODULE__,
+      {EngineRunner, %{engine_config_raw_json: engine_config_json}}
+    )
   end
 
   @impl true
@@ -34,7 +34,7 @@ defmodule DarkWorldsServer.Engine do
     |> DynamicSupervisor.which_children()
     |> Enum.filter(fn children ->
       case children do
-        {:undefined, pid, :worker, [Runner]} when is_pid(pid) -> true
+        {:undefined, pid, :worker, [EngineRunner]} when is_pid(pid) -> true
         _ -> false
       end
     end)

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -29,14 +29,6 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
   end
 
   if Mix.env() == :dev do
-    def enable() do
-      config =
-        Application.get_env(:dark_worlds_server, DarkWorldsServer.Engine.Runner)
-        |> Keyword.put(:use_engine_runner, true)
-
-      Application.put_env(:dark_worlds_server, DarkWorldsServer.Engine.Runner, config)
-    end
-
     def bot_join(pid_middle_number) do
       join(:c.pid(0, pid_middle_number, 0), "bot", "h4ck")
     end

--- a/server/lib/dark_worlds_server/engine/runner.ex
+++ b/server/lib/dark_worlds_server/engine/runner.ex
@@ -2,10 +2,8 @@ defmodule DarkWorldsServer.Engine.Runner do
   use GenServer, restart: :transient
   require Logger
   alias DarkWorldsServer.Communication
-  alias DarkWorldsServer.Engine
   alias DarkWorldsServer.Engine.ActionOk
   alias DarkWorldsServer.Engine.BotPlayer
-  alias DarkWorldsServer.Engine.EngineRunner
   alias DarkWorldsServer.Engine.Game
   alias DarkWorldsServer.Engine.PlayerTracker
 
@@ -356,15 +354,7 @@ defmodule DarkWorldsServer.Engine.Runner do
       {:finish_character_selection, selected_players, gen_server_state.client_game_state.game.myrra_state.players}
     )
 
-    ## Shutdown this runner and create a engine_runner instead
-    config = Application.get_env(:dark_worlds_server, __MODULE__)
-
-    if config[:use_engine_runner] do
-      setup_engine_runner(selected_players)
-      {:stop, :normal, gen_server_state}
-    else
-      {:noreply, gen_server_state}
-    end
+    {:noreply, gen_server_state}
   end
 
   def handle_info(:check_player_amount, gen_server_state) do
@@ -600,22 +590,5 @@ defmodule DarkWorldsServer.Engine.Runner do
 
       [new_item | acc_config]
     end)
-  end
-
-  defp setup_engine_runner(selected_players) do
-    ## Start engine_runner
-    {:ok, engine_runner_pid} = Engine.start_engine_runner()
-
-    ## Setup each player in engine_runner
-    Enum.each(selected_players, fn {id, name} ->
-      :ok = EngineRunner.join(engine_runner_pid, id, String.downcase(name))
-    end)
-
-    ## Start the game ticks
-    EngineRunner.start_game_tick(engine_runner_pid)
-
-    ## Tell runner subs that there is a new runner (engine_runner)
-    msg = {:change_to_engine_runner, engine_runner_pid, Communication.pubsub_game_topic(engine_runner_pid)}
-    Phoenix.PubSub.broadcast(DarkWorldsServer.PubSub, Communication.pubsub_game_topic(self()), msg)
   end
 end

--- a/server/lib/dark_worlds_server/matchmaking/matching_session.ex
+++ b/server/lib/dark_worlds_server/matchmaking/matching_session.ex
@@ -142,6 +142,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingSession do
       {:player_added, player_id, player_name, state.host_player_id, state.players}
     )
 
+    send(self(), :is_lobby_full?)
     {:noreply, state}
   end
 
@@ -153,6 +154,14 @@ defmodule DarkWorldsServer.Matchmaking.MatchingSession do
     )
 
     {:noreply, state}
+  end
+
+  def handle_info(:is_lobby_full?, state) do
+    # TODO start the game when lobby is full
+    case Enum.count(state[:players]) do
+      10 -> {:stop, :normal, state}
+      _ -> {:noreply, state}
+    end
   end
 
   def handle_info(:pong, state) do

--- a/server/lib/dark_worlds_server/matchmaking/matching_session.ex
+++ b/server/lib/dark_worlds_server/matchmaking/matching_session.ex
@@ -108,6 +108,27 @@ defmodule DarkWorldsServer.Matchmaking.MatchingSession do
     ## Start the game ticks
     EngineRunner.start_game_tick(game_pid)
 
+    # TODO We must delete this. It's a temporary workaround to send the config that
+    # the client needs from the server. This is done by GameConfig but the client
+    # will not send it anymore.
+    game_config =
+      %{
+        runner_config:
+          Utils.Config.read_config(:game_settings)
+          |> Enum.map(fn {k, v} ->
+            value =
+              case Integer.parse(v) do
+                :error -> v
+                {parsed_value, _} -> parsed_value
+              end
+
+            {k, value}
+          end)
+          |> Map.new(),
+        character_config: Utils.Config.read_config(:characters),
+        skills_config: Utils.Config.read_config(:skills)
+      }
+
     Phoenix.PubSub.broadcast!(DarkWorldsServer.PubSub, state[:topic], {:game_started, game_pid, game_config})
 
     {:stop, :normal, state}

--- a/server/lib/dark_worlds_server/utils/config/config.ex
+++ b/server/lib/dark_worlds_server/utils/config/config.ex
@@ -1,0 +1,22 @@
+defmodule Utils.Config do
+  @streaming_assets_path "../client/Assets/StreamingAssets/"
+
+  @spec read_config(atom) :: map | {:error, term}
+  def read_config(type) do
+    with path <- get_config_type_filepath(type),
+         {:ok, body} <- File.read(path),
+         body <- remove_bom(body),
+         {:ok, json} <- Jason.decode(body, keys: :atoms) do
+      json
+    else
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp get_config_type_filepath(:characters), do: Path.absname(@streaming_assets_path <> "Characters.json")
+  defp get_config_type_filepath(:game_settings), do: Path.absname(@streaming_assets_path <> "GameSettings.json")
+  defp get_config_type_filepath(:skills), do: Path.absname(@streaming_assets_path <> "Skills.json")
+
+  defp remove_bom(str), do: String.replace_prefix(str, "\uFEFF", "")
+end

--- a/server/lib/dark_worlds_server_web/controllers/lobby_controller.ex
+++ b/server/lib/dark_worlds_server_web/controllers/lobby_controller.ex
@@ -20,4 +20,14 @@ defmodule DarkWorldsServerWeb.LobbyController do
 
     json(conn, %{lobbies: lobbies, server_version: @server_hash})
   end
+
+  def join(conn, _params) do
+    matchmaking_pid =
+      case MatchingSupervisor.children_pids() do
+        [] -> Matchmaking.create_session()
+        [matchmaking_pid] -> matchmaking_pid
+      end
+
+    json(conn, %{lobby_id: Communication.pid_to_external_id(matchmaking_pid)})
+  end
 end

--- a/server/lib/dark_worlds_server_web/controllers/session_controller.ex
+++ b/server/lib/dark_worlds_server_web/controllers/session_controller.ex
@@ -4,18 +4,7 @@ defmodule DarkWorldsServerWeb.SessionController do
   alias DarkWorldsServer.Engine
 
   def new(conn, _params) do
-    {:ok, runner_pid} =
-      Engine.start_child(%{
-        players: [1],
-        game_config: %{
-          runner_config: %{
-            board_width: 1000,
-            board_height: 1000,
-            server_tickrate_ms: 30,
-            game_timeout_ms: 1_200_000
-          }
-        }
-      })
+    {:ok, runner_pid} = Engine.start_child()
 
     headers = Enum.into(conn.req_headers, %{})
     session_id = Communication.pid_to_external_id(runner_pid)

--- a/server/lib/dark_worlds_server_web/router.ex
+++ b/server/lib/dark_worlds_server_web/router.ex
@@ -31,6 +31,7 @@ defmodule DarkWorldsServerWeb.Router do
     # get "/new_session", SessionController, :new
     get "/new_lobby", LobbyController, :new
     get "/current_lobbies", LobbyController, :current_lobbies
+    get "/join_lobby", LobbyController, :join
     get "/current_games", GameController, :current_games
     get "/player_game/:player_id", GameController, :player_game
   end

--- a/server/lib/dark_worlds_server_web/websockets/play_websocket.ex
+++ b/server/lib/dark_worlds_server_web/websockets/play_websocket.ex
@@ -40,12 +40,14 @@ defmodule DarkWorldsServerWeb.PlayWebSocket do
   #   {:stop, :version_mismatch}
   # end
 
-  def websocket_init(%{game_id: game_id, player_id: player_id, client_id: client_id}) do
+  def websocket_init(%{game_id: game_id, player_id: player_id, client_id: _client_id}) do
     runner_pid = Communication.external_id_to_pid(game_id)
 
     with :ok <- Phoenix.PubSub.subscribe(DarkWorldsServer.PubSub, "game_play_#{game_id}"),
-         true <- runner_pid in Engine.list_runners_pids(),
-         {:ok, player_id} <- Runner.join(runner_pid, client_id, String.to_integer(player_id)) do
+         true <- runner_pid in Engine.list_runners_pids() do
+      # TODO this must be restored but the websocket is not starting for the host player.
+      # The MatchingSession will add the players in the meantime.
+      # {:ok, player_id} <- Runner.join(runner_pid, client_id, String.to_integer(player_id)) do
       web_socket_state = %{runner_pid: runner_pid, player_id: player_id, game_id: game_id}
 
       Process.send_after(self(), :send_ping, @ping_interval_ms)


### PR DESCRIPTION
Closes #956 

### Motivation
We will switch the current flow of the game to the following:
* Players will join a lobby with a button.
* This lobby will automatically start after one of the desired conditions are met (time's up, lobby is full, etc.)
* Players will have the character selected before triggering the 1st step.

### Summary of changes
- [Add new join lobby endpoint](https://github.com/lambdaclass/curse_of_myrra/pull/1071/commits/899c5742b609600037dc26d22c463b9fd9ca8202)
- [Refactor MatchingSession, Runner and EngineRunner behavior.](https://github.com/lambdaclass/curse_of_myrra/pull/1071/commits/bfb08fa1fef6ab5595ca27470702abcae2eb24a1)
- [Send the old config needed by the client from the server](https://github.com/lambdaclass/curse_of_myrra/pull/1071/commits/06fd39ba64ec92076c87879583ab3433528f2fa5)
- [Add new start game trigger when the lobby is full](https://github.com/lambdaclass/curse_of_myrra/pull/1071/commits/6338ef042c93339858de21cfb96714aabebf9946)

### Things to be aware of
- Left some TODO's in the code:
  - The play_websocket.ex should handle the join of the players, not the MatchingSession.
  - The old config is sent to the client by the server, this should be deleted when the new server config is properly connected with the client.
  - The 'lobby is full' condition to launch the game is not developed yet.

### How to test it
I encourage the reviewer to test it with other people using the same branch and ngrok.
- Use the "new lobby" button to create/search a lobby (this is done automatically).
- There are 10 seconds to be in the same lobby with something else.
- Other players but the host will go to "select character" screen.
  - @AminArria told me something about this. I'm not sure why the host doesn't move on in the client side.