### PR TITLE
Add template for pull-requests descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+Closes #[issue]
+
+## Motivation
+
+Explain why not how.
+
+## Summary of changes
+
+List changes in code.
+
+## How has this been tested?
+
+Describe the steps you performed to test this PR.
+
+## Test additions / changes
+
+List tests added/updated.
+
+## Checklist
+- [ ] I have tested the changes locally.
+- [ ] I self-reviewed the changes on GitHub, line by line.
+- [ ] Tests have been added/updated.
+- [ ] This change requires new documentation.
+  - [ ] Documentation has been added/updated.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,6 @@ List tests added/updated.
 - [ ] Tests have been added/updated.
 - [ ] This change requires new documentation.
   - [ ] Documentation has been added/updated.
+- [ ] I have tested the changes in another devices.
+  - [ ] Tested in iOS.
+  - [ ] Tested in Android.


### PR DESCRIPTION
Sometimes the PRs descriptions don't give you enough context or explain more than it should.
With a template we standardize what we want to tell to the reviewers about the PR.