### PR TITLE
[GH-1086] Fix projectiles appearing in the center of the map at spawn frame

### DIFF
--- a/client/Assets/Scripts/Battle.cs
+++ b/client/Assets/Scripts/Battle.cs
@@ -353,12 +353,11 @@ public class Battle : MonoBehaviour
         GameObject projectile;
         for (int i = 0; i < gameProjectiles.Count; i++)
         {
+            Vector3 backToFrontPosition = Utils.transformBackendPositionToFrontendPosition(
+                gameProjectiles[i].Position
+            );
             if (projectiles.TryGetValue((int)gameProjectiles[i].Id, out projectile))
             {
-                Vector3 backToFrontPosition = Utils.transformBackendPositionToFrontendPosition(
-                    gameProjectiles[i].Position
-                );
-
                 projectile
                     .GetComponent<SkillProjectile>()
                     .UpdatePosition(
@@ -381,7 +380,7 @@ public class Battle : MonoBehaviour
                     .First()
                     .projectilePrefab;
                 GameObject skillProjectile = GetComponent<ProjectileHandler>()
-                    .InstanceProjectile(projectileFromSkill, angle);
+                    .InstanceProjectile(projectileFromSkill, angle, new Vector3(backToFrontPosition[0], 3f, backToFrontPosition[2]));
 
                 projectiles.Add((int)gameProjectiles[i].Id, skillProjectile);
             }

--- a/client/Assets/Scripts/Projectiles/ProjectileHandler.cs
+++ b/client/Assets/Scripts/Projectiles/ProjectileHandler.cs
@@ -23,15 +23,15 @@ public class ProjectileHandler : MonoBehaviour
         }
     }
 
-    public GameObject InstanceProjectile(GameObject skillProjectile, float direction)
+    public GameObject InstanceProjectile(GameObject skillProjectile, float direction, Vector3 initialPosition)
     {
         MMSimpleObjectPooler projectileFromPooler = objectPoolerList.Find(
             objectPooler => objectPooler.name.Contains(skillProjectile.name)
         );
         GameObject pooledGameObject = projectileFromPooler.GetPooledGameObject();
-        pooledGameObject.SetActive(true);
-        pooledGameObject.transform.position = transform.position;
+        pooledGameObject.transform.position = initialPosition;
         pooledGameObject.transform.rotation = Quaternion.Euler(0, direction, 0);
+        pooledGameObject.SetActive(true);
 
         return pooledGameObject;
     }

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -12,7 +12,6 @@ public class SocketConnectionManager : MonoBehaviour
     public List<GameObject> players;
 
     public Dictionary<int, GameObject> projectiles = new Dictionary<int, GameObject>();
-    public static Dictionary<int, GameObject> projectilesStatic;
 
     [Tooltip("Session ID to connect to. If empty, a new session will be created")]
     public string sessionId = "";
@@ -96,7 +95,6 @@ public class SocketConnectionManager : MonoBehaviour
             this.serverHash = LobbyConnection.Instance.serverHash;
             this.clientId = LobbyConnection.Instance.clientId;
             this.reconnect = LobbyConnection.Instance.reconnect;
-            projectilesStatic = this.projectiles;
             DontDestroyOnLoad(gameObject);
 
             if (this.reconnect)


### PR DESCRIPTION
Closes #1086 

## Motivation

When shooting H4ck's basic attack (would've happened with any projectile) for a frame, those projectiles appeared in the center of the map, this is the position of the BattleManager game object that holds the ProjectileHandler script, which assigned it's own position, and by extension, BattleManager's position, to the projectiles on the spawn frame.

## Summary of changes

- Modified the UpdateProjectiles method in `Battle.cs` to calculate `backToFrontPosition`, whether the projectile already existed on the client or not.
- Added the `initialPosition` parameter to the `InstantiateProjectile` method inside `ProjectileHandler.cs` and assigned it as the `transform.position` of the pooled projectile before setting it as active.
- Pased the aformentioned `backToFrontPosition` variable to the `InstantiateProjectile` method to be the initial position of the projectile.

## How has this been tested?

Joined a game with H4ck, near the center of the map, where we always see the projectiles appear (which isn't the world's  (0, 0, 0) since battle manager is positioned in (-7.5, 0, 9.5), which was the place were the projectiles appeared), and fired the basic attack multiple times, verifying that no stranded projectile appeared in that spot.

## Test additions / changes

Haven't added or modified any test.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
