### PR TITLE
Fix Title Screen Controller

### DIFF
--- a/client/Assets/Scripts/UI/TitleScreenController.cs
+++ b/client/Assets/Scripts/UI/TitleScreenController.cs
@@ -24,7 +24,6 @@ public class TitleScreenController : MonoBehaviour
 
     void Start()
     {
-        PlayerPrefs.SetString("playerName", "");
         StartCoroutine(FadeIn(logoImage.GetComponent<CanvasGroup>(), 1f, .1f));
         StartCoroutine(FadeIn(playNowButton, .3f, 1.2f));
         StartCoroutine(FadeIn(changeNameButton, 1f, 1.2f));


### PR DESCRIPTION
## Motivation

A line used for testing purposes was left in the code, which set a blank string in the player's name every time the title screen started.

## Summary of changes

Removed this line from the `Start()` method in the `TitleScreenController`

## How has this been tested?

- Start the game
- Set a player name
- Restart the game
- The player name pop up should not appear

## Checklist
- [X] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
