### PR TITLE
Fix main screen scene character models references

### DIFF
--- a/client/Assets/Scenes/MainScreen.unity
+++ b/client/Assets/Scenes/MainScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37312195, g: 0.3807416, b: 0.3587262, a: 1}
+  m_IndirectSpecularColor: {r: 0.37087223, g: 0.37838233, b: 0.35725474, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -275,5 +275,45 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9166025620740607941, guid: 2e58a51401b054dda958456ff0440f6c,
+        type: 3}
+      propertyPath: playerModelContainer
+      value: 
+      objectReference: {fileID: 1183267380}
+    - target: {fileID: 9166025620740607941, guid: 2e58a51401b054dda958456ff0440f6c,
+        type: 3}
+      propertyPath: playerModels.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166025620740607941, guid: 2e58a51401b054dda958456ff0440f6c,
+        type: 3}
+      propertyPath: playerModels.Array.data[0]
+      value: 
+      objectReference: {fileID: 6095740820604997444, guid: 9ff4213cc4e554ae1a91a77d78a5a45c,
+        type: 3}
+    - target: {fileID: 9166025620740607941, guid: 2e58a51401b054dda958456ff0440f6c,
+        type: 3}
+      propertyPath: playerModels.Array.data[1]
+      value: 
+      objectReference: {fileID: 6900841105287980393, guid: 53ddc2867d2b7405bbc465b1369df3b0,
+        type: 3}
+    - target: {fileID: 9166025620740607941, guid: 2e58a51401b054dda958456ff0440f6c,
+        type: 3}
+      propertyPath: playerModels.Array.data[2]
+      value: 
+      objectReference: {fileID: 7614442363252852431, guid: cf05724cdff664becbb779c9c31dfdf0,
+        type: 3}
+    - target: {fileID: 9166025620740607941, guid: 2e58a51401b054dda958456ff0440f6c,
+        type: 3}
+      propertyPath: playerModels.Array.data[3]
+      value: 
+      objectReference: {fileID: 6228012723187808227, guid: 6ab80e0330e104468bb83c97f67ae1c9,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e58a51401b054dda958456ff0440f6c, type: 3}
+--- !u!1 &1183267380 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2160659356440150380, guid: 2e58a51401b054dda958456ff0440f6c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1183267379}
+  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
## Motivation

The references for the character models to appear on the main screen scene were broken, causing an error when entering that scene.

## Summary of changes

Added the references to the Player Model Container in the scene and to the characters model variants to display.

## How has this been tested?

Start the game and verify when you get to the main scene that there are no errors and that one of the character's model is shown in the center of the screen.

## Test additions / changes

No tests added or updated

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line. (Only changes in references, no code humanly readable)
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
