### PR TITLE
[GH-1126] Fix end game backend bugs

### DIFF
--- a/client/Assets/Scripts/UI/DeathSplash/DeathSplashManager.cs
+++ b/client/Assets/Scripts/UI/DeathSplash/DeathSplashManager.cs
@@ -89,7 +89,17 @@ public class DeathSplashManager : MonoBehaviour
             SocketConnectionManager.Instance.playerId
         );
 
-        return isWinner ? WINNER_POS : Utils.GetAlivePlayers().Count() + 1;
+        // FIXME This is a temporal for the cases where the winner dies simultaneously
+        // FIXME with other/s player/s
+        if (isWinner)
+        {
+            return WINNER_POS;
+        }
+        if (Utils.GetAlivePlayers().Count() == 0)
+        {
+            return 2;
+        }
+        return Utils.GetAlivePlayers().Count() + 1;
     }
 
     void ShowMessage()

--- a/client/Assets/Scripts/UI/DeathSplash/DeathSplashManager.cs
+++ b/client/Assets/Scripts/UI/DeathSplash/DeathSplashManager.cs
@@ -52,6 +52,7 @@ public class DeathSplashManager : MonoBehaviour
     List<GameObject> characterModels;
 
     private const int WINNER_POS = 1;
+    private const int SECOND_PLACE_POS = 2;
     private const string WINNER_MESSAGE = "THE KING OF ARABAN!";
     private const string LOSER_MESSAGE = "BETTER LUCK NEXT TIME!";
     GameObject player;
@@ -97,7 +98,7 @@ public class DeathSplashManager : MonoBehaviour
         }
         if (Utils.GetAlivePlayers().Count() == 0)
         {
-            return 2;
+            return SECOND_PLACE_POS;
         }
         return Utils.GetAlivePlayers().Count() + 1;
     }

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -174,7 +174,13 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
       Map.put(game_state, :player_timestamps, state.player_timestamps)
     )
 
-    {:noreply, %{state | game_state: game_state, last_game_tick_at: now, last_standing_players: update_last_standing_players(state)}}
+    {:noreply,
+     %{
+       state
+       | game_state: game_state,
+         last_game_tick_at: now,
+         last_standing_players: update_last_standing_players(state)
+     }}
   end
 
   def handle_info(:spawn_loot, state) do
@@ -285,11 +291,17 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
     players_alive = Enum.filter(players, fn player -> player.status == :alive end)
 
     case players_alive do
-      ^players -> :ongoing
-      [_, _ | _] -> :ongoing
-      [player] -> {:ended, player}
+      ^players ->
+        :ongoing
+
+      [_, _ | _] ->
+        :ongoing
+
+      [player] ->
+        {:ended, player}
+
       [] ->
-        # FIXME we should use a tiebreaker instead of picking the 1st one in the list
+        # TODO we should use a tiebreaker instead of picking the 1st one in the list
         {:ended, hd(last_standing_players)}
     end
   end

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -84,7 +84,8 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
       player_timestamps: %{},
       broadcast_topic: Communication.pubsub_game_topic(self()),
       user_to_player: %{},
-      bot_handler_pid: nil
+      bot_handler_pid: nil,
+      last_standing_players: []
     }
 
     Process.put(:map_size, {engine_config.game.width, engine_config.game.height})
@@ -173,7 +174,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
       Map.put(game_state, :player_timestamps, state.player_timestamps)
     )
 
-    {:noreply, %{state | game_state: game_state, last_game_tick_at: now}}
+    {:noreply, %{state | game_state: game_state, last_game_tick_at: now, last_standing_players: update_last_standing_players(state)}}
   end
 
   def handle_info(:spawn_loot, state) do
@@ -187,7 +188,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
   def handle_info(:check_game_ended, state) do
     Process.send_after(self(), :check_game_ended, @check_game_ended_interval_ms)
 
-    case check_game_ended(Map.values(state.game_state.players)) do
+    case check_game_ended(Map.values(state.game_state.players), state.last_standing_players) do
       :ongoing ->
         :skip
 
@@ -260,6 +261,15 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
     )
   end
 
+  defp update_last_standing_players(%{last_standing_players: last_standing_players} = state) do
+    players_alive = Enum.filter(Map.values(state.game_state.players), fn player -> player.status == :alive end)
+
+    case players_alive do
+      [] -> last_standing_players
+      players_alive -> players_alive
+    end
+  end
+
   defp broadcast_game_ended(topic, winner, game_state) do
     myrra_winner = transform_player_to_myrra_player(winner)
     myrra_state = transform_state_to_myrra_state(game_state)
@@ -271,14 +281,16 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
     )
   end
 
-  defp check_game_ended(players) do
+  defp check_game_ended(players, last_standing_players) do
     players_alive = Enum.filter(players, fn player -> player.status == :alive end)
 
     case players_alive do
       ^players -> :ongoing
       [_, _ | _] -> :ongoing
       [player] -> {:ended, player}
-      [] -> {:ended, nil}
+      [] ->
+        # FIXME we should use a tiebreaker instead of picking the 1st one in the list
+        {:ended, hd(last_standing_players)}
     end
   end
 

--- a/server/lib/dark_worlds_server_web/websockets/lobby_websocket.ex
+++ b/server/lib/dark_worlds_server_web/websockets/lobby_websocket.ex
@@ -50,6 +50,12 @@ defmodule DarkWorldsServerWeb.LobbyWebsocket do
     :ok
   end
 
+  def terminate(reason, _req, _state) do
+    log_termination(reason)
+
+    :ok
+  end
+
   defp log_termination({_, 1000, _} = reason) do
     Logger.info("#{__MODULE__} with PID #{inspect(self())} closed with message: #{inspect(reason)}")
   end


### PR DESCRIPTION
Closes #1126 

## Motivation

The game should terminate without errors to prevent weird behavior of the game.

## Summary of changes

- [Add terminate/3 clause in LobbyWebsocket to show log info instead of an error](https://github.com/lambdaclass/curse_of_myrra/pull/1137/commits/7106011fc42b7ff8ef134d67c5ffd1be6156110e)
- [Save alive players in every tick and pick one of them as winner when the end game condition is met](https://github.com/lambdaclass/curse_of_myrra/pull/1137/commits/5e292ef3e7ca55980fcfbf0ad469a45cbc1d1baa)
- [Fix winner player final place in game when all players are dead](https://github.com/lambdaclass/curse_of_myrra/pull/1137/commits/3faf2a27c086f6d8af7141cfd9af956d327cf526)

## How has this been tested?

- Tested alone dying by the zone.
- Tested with my phone as a second player:
  - Both dying at the same time by the zone.
  - Killing each player by any means in any order.

## Test additions / changes

No tests.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
