### PR TITLE
fix backend not sending timestamps properly

### DIFF
--- a/client/Assets/Scripts/Battle.cs
+++ b/client/Assets/Scripts/Battle.cs
@@ -381,7 +381,11 @@ public class Battle : MonoBehaviour
                     .First()
                     .projectilePrefab;
                 GameObject skillProjectile = GetComponent<ProjectileHandler>()
-                    .InstanceProjectile(projectileFromSkill, angle, new Vector3(backToFrontPosition[0], 3f, backToFrontPosition[2]));
+                    .InstanceProjectile(
+                        projectileFromSkill,
+                        angle,
+                        new Vector3(backToFrontPosition[0], 3f, backToFrontPosition[2])
+                    );
 
                 projectiles.Add((int)gameProjectiles[i].Id, skillProjectile);
             }

--- a/client/Assets/Scripts/ClientPrediction.cs
+++ b/client/Assets/Scripts/ClientPrediction.cs
@@ -21,6 +21,7 @@ public class ClientPrediction
     public void simulatePlayerState(Player player, long timestamp)
     {
         removeServerAcknowledgedInputs(player, timestamp);
+        Debug.Log("pendingPlayerInputs.Count: " + pendingPlayerInputs.Count);
         simulatePlayerMovement(player);
     }
 
@@ -36,11 +37,10 @@ public class ClientPrediction
 
         pendingPlayerInputs.ForEach(input =>
         {
-            Vector2 movementDirection;
-            if (player.Effects.ContainsKey((ulong)PlayerEffect.DanseMacabre))
-                movementDirection = new Vector2(input.joystick_x_value, input.joystick_y_value);
-            else
-                movementDirection = new Vector2(-input.joystick_y_value, input.joystick_x_value);
+            Vector2 movementDirection = new Vector2(
+                -input.joystick_y_value,
+                input.joystick_x_value
+            );
 
             movementDirection.Normalize();
             Vector2 movementVector = movementDirection * characterSpeed;

--- a/client/Assets/Scripts/ClientPrediction.cs
+++ b/client/Assets/Scripts/ClientPrediction.cs
@@ -21,7 +21,6 @@ public class ClientPrediction
     public void simulatePlayerState(Player player, long timestamp)
     {
         removeServerAcknowledgedInputs(player, timestamp);
-        Debug.Log("pendingPlayerInputs.Count: " + pendingPlayerInputs.Count);
         simulatePlayerMovement(player);
     }
 

--- a/server/lib/dark_worlds_server/engine/bot_player.ex
+++ b/server/lib/dark_worlds_server/engine/bot_player.ex
@@ -25,11 +25,14 @@ defmodule DarkWorldsServer.Engine.BotPlayer do
   # Number to substract to the playable radio
   @radius_sub_to_escape 500
 
+  # This is the amount of time between bots messages
+  @game_tick_rate_ms 30
+
   #######
   # API #
   #######
-  def start_link(game_pid, tick_rate) do
-    GenServer.start_link(__MODULE__, {game_pid, tick_rate})
+  def start_link(game_pid, _args) do
+    GenServer.start_link(__MODULE__, {game_pid, @game_tick_rate_ms})
   end
 
   def add_bot(bot_pid, bot_id) do

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -216,7 +216,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
   end
 
   def handle_info( {:spawn_bots, bot_count}, state) when bot_count > 0 do
-    {:ok, bot_handler_pid} = BotPlayer.start_link(self(), _)
+    {:ok, bot_handler_pid} = BotPlayer.start_link(self(), %{})
 
     {game_state, bots_ids} = Enum.reduce(0..(bot_count - 1), {state.game_state, []}, fn (_, {acc_game_state, bots}) ->
       character = Enum.random(["h4ck", "muflus"])

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -7,7 +7,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
   alias DarkWorldsServer.Engine.BotPlayer
 
   # This is the amount of time between state updates in milliseconds
-  @game_tick_rate_ms 30
+  @game_tick_rate_ms 20
   # Amount of time between loot spawn
   @loot_spawn_rate_ms 20_000
   # Amount of time between loot spawn

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -121,7 +121,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
 
     state =
       Map.put(state, :game_state, game_state)
-      |> put_in([:player_timestamps, player_id], timestamp)
+      |> put_in([:player_timestamps, user_id], timestamp)
 
     {:noreply, state}
   end
@@ -141,7 +141,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
 
     state =
       Map.put(state, :game_state, game_state)
-      |> put_in([:player_timestamps, player_id], timestamp)
+      |> put_in([:player_timestamps, user_id], timestamp)
 
     {:noreply, state}
   end

--- a/server/lib/dark_worlds_server/engine/engine_runner.ex
+++ b/server/lib/dark_worlds_server/engine/engine_runner.ex
@@ -216,7 +216,7 @@ defmodule DarkWorldsServer.Engine.EngineRunner do
   end
 
   def handle_info( {:spawn_bots, bot_count}, state) when bot_count > 0 do
-    {:ok, bot_handler_pid} = BotPlayer.start_link(self(), @game_tick_rate_ms)
+    {:ok, bot_handler_pid} = BotPlayer.start_link(self(), _)
 
     {game_state, bots_ids} = Enum.reduce(0..(bot_count - 1), {state.game_state, []}, fn (_, {acc_game_state, bots}) ->
       character = Enum.random(["h4ck", "muflus"])

--- a/server/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/server/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -51,8 +51,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   @impl true
   def handle_info({:check_timeout, session_ref}, %{session: session_ref, players: [_ | _]} = state) do
-    #bot_count = @session_player_amount - length(state.players)
-    bot_count = 0
+    bot_count = @session_player_amount - length(state.players)
     {:ok, game_pid, engine_config} = start_game(bot_count)
     players = consume_and_notify_players(state.players, game_pid, engine_config, @session_player_amount)
     new_session_ref = make_ref()

--- a/server/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/server/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -51,7 +51,8 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   @impl true
   def handle_info({:check_timeout, session_ref}, %{session: session_ref, players: [_ | _]} = state) do
-    bot_count = @session_player_amount - length(state.players)
+    #bot_count = @session_player_amount - length(state.players)
+    bot_count = 0
     {:ok, game_pid, engine_config} = start_game(bot_count)
     players = consume_and_notify_players(state.players, game_pid, engine_config, @session_player_amount)
     new_session_ref = make_ref()


### PR DESCRIPTION
## Motivation

We are missing the timestamps for the players, so we are unable to clean the client prediction updates queue.

## Summary of changes

- fix the timestamps players key
- clean some code
- separate bots process tick from server game tick

## Test additions / changes

List tests added/updated.

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
