### PR TITLE
Add main to editor build settings

### DIFF
--- a/client/ProjectSettings/EditorBuildSettings.asset
+++ b/client/ProjectSettings/EditorBuildSettings.asset
@@ -9,6 +9,9 @@ EditorBuildSettings:
     path: Assets/Scenes/TitleScreen.unity
     guid: 4900ba75a16aa4edbb73129a2a725d34
   - enabled: 1
+    path: Assets/Scenes/MainScreen.unity
+    guid: e82d32a8f63314ac3952d12e1e5eb447
+  - enabled: 1
     path: Assets/Scenes/Lobby.unity
     guid: eca446aa72db645d9835a2bf3d9cfc7d
   - enabled: 1


### PR DESCRIPTION
## Motivation

Some builds branched from main do not work because they are missing the main scene in the editor builder settings

## Summary of changes

This PR adds main to the editor build settings

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
