### PR TITLE
Fix Foreground bar from health bar

### DIFF
--- a/client/Assets/Prefabs/HealthBar.prefab
+++ b/client/Assets/Prefabs/HealthBar.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 100
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &114091369736583034
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Motivation

There was a reference error preventing the user to start a match as the new muflus

## Summary of changes

I re-referenced the foreground bar in the MMProgressBar component

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
