### PR TITLE
[GH-1197] get ids from gamePlayers instead of simple counter

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -168,8 +168,9 @@ public class CustomLevelManager : LevelManager
         // prefab = prefab == null ? quickGamePrefab : prefab;
         for (ulong i = 0; i < totalPlayers; i++)
         {
-            prefab = GetCharacterPrefab(i + 1);
-            if (SocketConnectionManager.Instance.playerId == i + 1)
+            ulong playerID = gamePlayers[(int)i].Id;
+            prefab = GetCharacterPrefab(playerID);
+            if (SocketConnectionManager.Instance.playerId == playerID)
             {
                 // Player1 is the ID to match with the client InputManager
                 prefab.GetComponent<CustomCharacter>().PlayerID = "Player1";
@@ -184,7 +185,7 @@ public class CustomLevelManager : LevelManager
                 Quaternion.identity
             );
             newPlayer.name = "Player" + " " + (i + 1);
-            newPlayer.PlayerID = (i + 1).ToString();
+            newPlayer.PlayerID = playerID.ToString();
 
             SocketConnectionManager.Instance.players.Add(newPlayer.gameObject);
             this.Players.Add(newPlayer);


### PR DESCRIPTION
Closes #1197

## Motivation

Can't test load tests while playing a game on unity (if my client gets matched with the load test's clients)

## Summary of changes

- [get ids from gamePlayers instead of simple counter](https://github.com/lambdaclass/curse_of_myrra/pull/1198/commits/c1f9469f5af80c6de83820bde03b6e119690c159)

## How has this been tested?

Tested locally by starting a new game and quickly running a round of the load test (I mention the steps on the issue)

## Test additions / changes

List tests added/updated.

## Checklist
- [X] I have tested the changes locally.
- [X] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
