### PR TITLE
force http for load testing servers

### DIFF
--- a/client/Assets/Scripts/LobbyConnection.cs
+++ b/client/Assets/Scripts/LobbyConnection.cs
@@ -425,6 +425,16 @@ public class LobbyConnection : MonoBehaviour
         {
             return "http://" + serverIp + ":4000" + path;
         }
+        // Load test server
+        else if (serverIp.Contains("168.119.71.104"))
+        {
+            return "http://" + serverIp + ":4000" + path;
+        }
+        // Load test runner server
+        else if (serverIp.Contains("176.9.26.172"))
+        {
+            return "http://" + serverIp + ":4000" + path;
+        }
         else
         {
             return "https://" + serverIp + path;
@@ -438,6 +448,16 @@ public class LobbyConnection : MonoBehaviour
             return "ws://" + serverIp + ":4000" + path;
         }
         else if (serverIp.Contains("10.150.20.186"))
+        {
+            return "ws://" + serverIp + ":4000" + path;
+        }
+        // Load test server
+        else if (serverIp.Contains("168.119.71.104"))
+        {
+            return "ws://" + serverIp + ":4000" + path;
+        }
+        // Load test runner server
+        else if (serverIp.Contains("176.9.26.172"))
         {
             return "ws://" + serverIp + ":4000" + path;
         }

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -287,6 +287,16 @@ public class SocketConnectionManager : MonoBehaviour
         {
             return "http://" + serverIp + ":" + port + path;
         }
+        // Load test server
+        else if (serverIp.Contains("168.119.71.104"))
+        {
+            return "http://" + serverIp + ":" + port + path;
+        }
+        // Load test runner server
+        else if (serverIp.Contains("176.9.26.172"))
+        {
+            return "http://" + serverIp + ":" + port + path;
+        }
         else
         {
             return "https://" + serverIp + path;
@@ -313,6 +323,16 @@ public class SocketConnectionManager : MonoBehaviour
             return "ws://" + serverIp + ":" + port + path;
         }
         else if (serverIp.Contains("10.150.20.186"))
+        {
+            return "ws://" + serverIp + ":" + port + path;
+        }
+        // Load test server
+        else if (serverIp.Contains("168.119.71.104"))
+        {
+            return "ws://" + serverIp + ":" + port + path;
+        }
+        // Load test runner server
+        else if (serverIp.Contains("176.9.26.172"))
         {
             return "ws://" + serverIp + ":" + port + path;
         }


### PR DESCRIPTION
Closes #1203

## Motivation

We need to create games on the load testing servers

## Summary of changes

- force http and ws for load testing server ips

## How has this been tested?

1. Made sure the load test server is up
2. Add the ip of the load testing server as a custom server:

<img width="299" alt="image" src="https://github.com/lambdaclass/curse_of_myrra/assets/25107475/8625ea6f-2a62-44db-92cc-e13a0a714e53">

## Test additions / changes

No tests added

## Checklist
- [X] I have tested the changes locally.
- [X] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
