### PR TITLE
Muflus anchor

### DIFF
--- a/client/Assets/Prefabs/Characters/UICharacters/Muflus.prefab
+++ b/client/Assets/Prefabs/Characters/UICharacters/Muflus.prefab
@@ -47,7 +47,7 @@ PrefabInstance:
     - target: {fileID: 160556957461763346, guid: 15b66cc26325d4624aa55f5dbede2d7d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 160556957461763346, guid: 15b66cc26325d4624aa55f5dbede2d7d,
         type: 3}
@@ -57,7 +57,7 @@ PrefabInstance:
     - target: {fileID: 160556957461763346, guid: 15b66cc26325d4624aa55f5dbede2d7d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 160556957461763346, guid: 15b66cc26325d4624aa55f5dbede2d7d,
         type: 3}


### PR DESCRIPTION
## Motivation

The rotation for muflus was not rotating properly

## Summary of changes

Muflus model was centered to make the rotation be at the character's center