### PR TITLE
PERFORMANCE ITERATION 3 - Fix insta game crash on low/mid devices

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -191,20 +191,7 @@ public class CustomLevelManager : LevelManager
             yield return new WaitForSeconds(1.7f);
             loadingScreen.SetActive(false);
             battleScreen.SetActive(true);
-            //Cancel camera movement and start zoom in
-            StartCoroutine(
-                Utils.GetCharacter(
-                        playerId)
-                    .characterBase.activateSpawnFeedback(true));
-            Utils
-                .GetAlivePlayers()
-                .Where(player => player.Id != playerId)
-                .ToList()
-                .ForEach(el => StartCoroutine(
-                    Utils.GetCharacter(
-                        el.Id)
-                    .characterBase.activateSpawnFeedback(false))
-                );
+            // Cancel camera movement and start zoom in
             yield return new WaitForSeconds(2.1f);
             CancelInvoke("Substract");
             InvokeRepeating("MoveYCamera", 0.3f, 0.1f);


### PR DESCRIPTION
## Motivation

The game had the problem that in LOW/MID devices it insta crash at the beginning of the battle.

You can see all the iteration steps in: 
https://www.notion.so/lambdaclass/Client-performance-benchmark-template-15145122c5464cc8870c02b24052aa81?pvs=4

## Summary of changes

After a huge debug we found that the cause of these crashes were the following code inside `CustomLevelManager`, `CameraCinematic` method

```
Utils
    .GetAlivePlayers()
    .Where(player => player.Id != playerId)
    .ToList()
    .ForEach(
        el =>
            StartCoroutine(
                Utils.GetCharacter(el.Id).characterBase.activateSpawnFeedback(false)
            )
    );

```
## How has this been tested?

Tested in the following mobiles phones:

`Tested on Xiomi redmi note 9s:`
Before: Insta Crash
After: Playable at 32 FPS the whole game

`Tested on Moto Edge 30 neo:`
Before: Insta Crash
After: Playable at 40 FPS the whole game

### Next Steps
Activate SpawnFeedback in all the players

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
