### PR TITLE
Muflus direction skill

### DIFF
--- a/client/Assets/ScriptableObjects/Skills/Muflus/Muflus_Melee.asset
+++ b/client/Assets/ScriptableObjects/Skills/Muflus/Muflus_Melee.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: BASH
   description: Targets an arc in front of you, dealing damage.
-  inputType: 0
+  inputType: 2
   skillSetType: 1
   angle: 0
   executeOnQuickTap: 0


### PR DESCRIPTION
## Motivation

Now all skills should have input types direction or area, resulting in joystick inputs.

## Summary of changes

This PR implements that. We are missing indicators but they are coming in a future PR 

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
