### PR TITLE
Left joystick opacity fix

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -17901,7 +17901,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7817028359507705854}
   m_Enabled: 1
-  m_Alpha: 0.5
+  m_Alpha: 1
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
@@ -17943,7 +17943,7 @@ MonoBehaviour:
       m_Calls: []
   RotatingIndicator: {fileID: 8219119912930584202}
   RotatingIndicatorThreshold: 0.1
-  PressedOpacity: 0.5
+  PressedOpacity: 0.4
   InterpolateOpacity: 1
   InterpolateOpacitySpeed: 1
   RawValue: {x: 0, y: 0}
@@ -19603,7 +19603,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9012026674244304607}
   m_Enabled: 1
-  m_Alpha: 0.3
+  m_Alpha: 0.1
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0

--- a/client/Assets/Scripts/UI/LeftMMTouchRepositionableJoystick.cs
+++ b/client/Assets/Scripts/UI/LeftMMTouchRepositionableJoystick.cs
@@ -6,13 +6,16 @@ public class LeftMMTouchRepositionableJoystick : MMTouchRepositionableJoystick
 {
     float positionX;
     float positionY;
-    const float initialJoystickOpacity = 0.3f;
-    const float pressedJoystickOpacity = 0.4f;
+
+    float initialJoystickOpacity;
+    float pressedJoystickOpacity;
     float scaleCanvas;
 
     protected override void Start()
     {
         base.Start();
+        initialJoystickOpacity = BackgroundCanvasGroup.alpha;
+        pressedJoystickOpacity = KnobCanvasGroup.GetComponent<LeftMMTouchJoystick>().PressedOpacity;
         scaleCanvas = GetComponentInParent<Canvas>().transform.localScale.x;
         _initialPosition = BackgroundCanvasGroup.transform.position;
     }


### PR DESCRIPTION
## Motivation

It was requested the left joystick starting opacity and pressed opacity were changed

## Summary of changes

This PR changes the opacity values for the left joystick. 
- The initial opacity is low since it is no longer needed for the user to see where is the movement joystick since the joystick will reposition and work for the user if they press in any position al the left side of the screen. 
- The pressed opacity is higher because it's important for the user to know where and if the joystick was effectively used

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
