### PR TITLE
Fix Araban lights

### DIFF
--- a/client/Assets/ArabanV2/Araban/Tents.mat
+++ b/client/Assets/ArabanV2/Araban/Tents.mat
@@ -10,8 +10,8 @@ Material:
   m_Name: Tents
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_ValidKeywords:
-  - _METALLICSPECGLOSSMAP
   - _NORMALMAP
+  - _RECEIVE_SHADOWS_OFF
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
@@ -52,7 +52,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
-        m_Texture: {fileID: 2800000, guid: 571dc761e366237469c3ab75b19a6c3f, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
@@ -99,8 +99,8 @@ Material:
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueOffset: 0
-    - _ReceiveShadows: 1
-    - _Smoothness: 0.5
+    - _ReceiveShadows: 0
+    - _Smoothness: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1

--- a/client/Assets/ArabanV2/Araban/desert-sand_graph_0/NewLayer.terrainlayer
+++ b/client/Assets/ArabanV2/Araban/desert-sand_graph_0/NewLayer.terrainlayer
@@ -19,4 +19,4 @@ TerrainLayer:
   m_DiffuseRemapMin: {x: 0, y: 0, z: 0, w: 0}
   m_DiffuseRemapMax: {x: 0.8392157, y: 0.8392157, z: 0.8392157, w: 1}
   m_MaskMapRemapMin: {x: 0, y: 0, z: 0, w: 0}
-  m_MaskMapRemapMax: {x: 1, y: 0.133, z: 1, w: 1}
+  m_MaskMapRemapMax: {x: 0, y: 0, z: 1, w: 0}

--- a/client/Assets/ArabanV2/Materials/desert-path_graph_0/NewLayer.terrainlayer
+++ b/client/Assets/ArabanV2/Materials/desert-path_graph_0/NewLayer.terrainlayer
@@ -19,4 +19,4 @@ TerrainLayer:
   m_DiffuseRemapMin: {x: 0, y: 0, z: 0, w: 0}
   m_DiffuseRemapMax: {x: 0.8396226, y: 0.8396226, z: 0.8396226, w: 1}
   m_MaskMapRemapMin: {x: 0, y: 0, z: 0, w: 0}
-  m_MaskMapRemapMax: {x: 1, y: 1, z: 1, w: 1}
+  m_MaskMapRemapMax: {x: 0, y: 0, z: 1, w: 0}

--- a/client/Assets/ArabanV2/Prefabs/NewLayer.terrainlayer
+++ b/client/Assets/ArabanV2/Prefabs/NewLayer.terrainlayer
@@ -19,4 +19,4 @@ TerrainLayer:
   m_DiffuseRemapMin: {x: 0, y: 0, z: 0, w: 1}
   m_DiffuseRemapMax: {x: 0.8392157, y: 0.8392157, z: 0.8392157, w: 1}
   m_MaskMapRemapMin: {x: 0, y: 0, z: 0, w: 0}
-  m_MaskMapRemapMax: {x: 1, y: 0.092, z: 1, w: 1}
+  m_MaskMapRemapMax: {x: 0, y: 0, z: 1, w: 0}

--- a/client/Assets/ArabanV2/Textures/Lava rocks diffuse.png.meta
+++ b/client/Assets/ArabanV2/Textures/Lava rocks diffuse.png.meta
@@ -101,6 +101,18 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []

--- a/client/Assets/ArabanV2/Textures/Lava rocks lava difusse.png.meta
+++ b/client/Assets/ArabanV2/Textures/Lava rocks lava difusse.png.meta
@@ -101,6 +101,18 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []

--- a/client/Assets/ArabanV2/Textures/NewLayer 1.terrainlayer
+++ b/client/Assets/ArabanV2/Textures/NewLayer 1.terrainlayer
@@ -19,4 +19,4 @@ TerrainLayer:
   m_DiffuseRemapMin: {x: 0, y: 0, z: 0, w: 0}
   m_DiffuseRemapMax: {x: 0.764151, y: 0.6149366, z: 0.58753115, w: 1}
   m_MaskMapRemapMin: {x: 0, y: 0, z: 0, w: 0}
-  m_MaskMapRemapMax: {x: 0.01639343, y: 0.09289618, z: 1, w: 0.28961748}
+  m_MaskMapRemapMax: {x: 0, y: 0, z: 1, w: 0}

--- a/client/Assets/ArabanV2/Textures/NewLayer 2.terrainlayer
+++ b/client/Assets/ArabanV2/Textures/NewLayer 2.terrainlayer
@@ -19,4 +19,4 @@ TerrainLayer:
   m_DiffuseRemapMin: {x: 0, y: 0, z: 0, w: 0}
   m_DiffuseRemapMax: {x: 0.8490566, y: 0.7595659, z: 0.74092203, w: 1}
   m_MaskMapRemapMin: {x: 0, y: 0, z: 0, w: 0}
-  m_MaskMapRemapMax: {x: 0, y: 0.005464487, z: 1, w: 0.420765}
+  m_MaskMapRemapMax: {x: 0, y: 0.005464487, z: 1, w: 0}

--- a/client/Assets/ArabanV2/Textures/NewLayer.terrainlayer
+++ b/client/Assets/ArabanV2/Textures/NewLayer.terrainlayer
@@ -19,4 +19,4 @@ TerrainLayer:
   m_DiffuseRemapMin: {x: 0, y: 0, z: 0, w: 0}
   m_DiffuseRemapMax: {x: 0.6509434, y: 0.58032215, z: 0.59175175, w: 1}
   m_MaskMapRemapMin: {x: 0, y: 0, z: 0, w: 0}
-  m_MaskMapRemapMax: {x: 0, y: 0.081967056, z: 1, w: 0.3661202}
+  m_MaskMapRemapMax: {x: 0, y: 0, z: 1, w: 0}

--- a/client/Assets/ArabanV2/Textures/desert_path_Base_Color.png.meta
+++ b/client/Assets/ArabanV2/Textures/desert_path_Base_Color.png.meta
@@ -101,6 +101,18 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []

--- a/client/Assets/ArabanV2/Textures/desert_sand_Base_Color.png.meta
+++ b/client/Assets/ArabanV2/Textures/desert_sand_Base_Color.png.meta
@@ -101,6 +101,18 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []


### PR DESCRIPTION
Closes #[issue]

## Motivation

Araban was looking too shiny on mobiles build. This fix that.

## Summary of changes

Changed Channel remapping of each texture in the terrain paint textures. 
- Mettalic to 0
- AO to 0
- Smoothness to 0

Removed the mettalic map from the tents material


## How has this been tested?

Make a build in any phone and terrain materials should not be shinning anymore.

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [x] Tested in iOS.
  - [x] Tested in Android.
