### PR TITLE
Simulate player joining to lobby

### DIFF
--- a/client/Assets/LobbyPlayerCounter.cs
+++ b/client/Assets/LobbyPlayerCounter.cs
@@ -22,6 +22,7 @@ public class LobbyPlayerCounter : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        _totalLobbyPlayersText.text = LobbyConnection.Instance.playerCount.ToString() + " / " + LobbyConnection.Instance.lobbyCapacity.ToString();
+        var playerAmount = Math.Max(LobbyConnection.Instance.playerCount, LobbyConnection.Instance.simulatedPlayerCount);
+        _totalLobbyPlayersText.text = playerAmount.ToString() + " / " + LobbyConnection.Instance.lobbyCapacity.ToString();
     }
 }

--- a/client/Assets/Scripts/LobbyConnection.cs
+++ b/client/Assets/Scripts/LobbyConnection.cs
@@ -21,6 +21,7 @@ public class LobbyConnection : MonoBehaviour
     public bool isHost = false;
     public ulong hostId;
     public int playerCount;
+    public int simulatedPlayerCount;
     public int lobbyCapacity;
     public Dictionary<ulong, string> playersIdName = new Dictionary<ulong, string>();
     public uint serverTickRate_ms;
@@ -143,6 +144,9 @@ public class LobbyConnection : MonoBehaviour
             ws.DispatchMessageQueue();
         }
 #endif
+    if (this.gameStarted) {
+        CancelInvoke("UpdateSimulatedCounter");
+    }
     }
 
     private void PopulateLists()
@@ -390,6 +394,7 @@ public class LobbyConnection : MonoBehaviour
                 case LobbyEventType.NotifyPlayerAmount:
                     this.playerCount = (int) lobbyEvent.AmountOfPlayers;
                     this.lobbyCapacity = (int) lobbyEvent.Capacity;
+                    InvokeRepeating("UpdateSimulatedCounter", 0, 1);
                     break;
 
                 default:
@@ -402,6 +407,13 @@ public class LobbyConnection : MonoBehaviour
         {
             Debug.Log("InvalidProtocolBufferException: " + e);
         }
+    }
+
+    private void UpdateSimulatedCounter() {
+        var limit = this.lobbyCapacity - this.simulatedPlayerCount;
+        System.Random r = new System.Random();
+        var randomNumber = r.Next(0, Math.Min(3, limit));
+        this.simulatedPlayerCount = this.simulatedPlayerCount + randomNumber;
     }
 
     private void OnWebsocketClose(WebSocketCloseCode closeCode)


### PR DESCRIPTION
Closes #[issue]

## Motivation

The new lobby player counter was too unnatural since it would jump from 1 to 10 in the last second

## Summary of changes

Added new repeating method to the lobby connection module that add a random amount to a new field to hold a fake count of players

## How has this been tested?

join a lobby in any server

## Test additions / changes

No test were added

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
